### PR TITLE
Add support for Devuan images

### DIFF
--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -1,0 +1,59 @@
+FROM devuan/devuan:daedalus
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get --assume-yes \
+            --no-install-recommends \
+            install debootstrap \
+                    debian-archive-keyring \
+                    ca-certificates \
+                    qemu-user \
+                    qemu-user-static \
+                    qemu-system-arm \
+                    qemu-system-x86 \
+                    device-tree-compiler \
+                    gcc \
+                    gcc-arm-none-eabi \
+                    make \
+                    git \
+                    bc \
+                    bzip2 \
+                    pigz \
+                    bison \
+                    flex \
+                    python3-dev \
+                    python3-pkg-resources \
+                    python3-pyelftools \
+                    python3-setuptools \
+                    swig \
+                    parted \
+                    e2fsprogs \
+                    dosfstools \
+                    mtools \
+                    pwgen \
+                    libssl-dev \
+                    libgnutls28-dev \
+                    uuid-dev \
+                    parallel \
+                    ssh \
+                    sshpass \
+                    unzip && \
+    ([ "$(uname -m)" = "aarch64" ] && \
+     apt-get --assume-yes \
+             install gcc-arm-linux-gnueabihf \
+                     gcc-i686-linux-gnu \
+                     gcc-x86-64-linux-gnu || :) && \
+    ([ "$(uname -m)" = "x86_64" ] && \
+     apt-get --assume-yes \
+             install gcc-arm-linux-gnueabihf \
+                     gcc-aarch64-linux-gnu \
+                     gcc-i686-linux-gnu || :) && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f /var/log/*.log
+RUN wget -q "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -O "awscliv2.zip" && \
+    unzip -q awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws
+ENV PATH="/debimg/scripts:${PATH}"
+COPY . /debimg
+WORKDIR /debimg

--- a/README_devuan.md
+++ b/README_devuan.md
@@ -1,0 +1,87 @@
+# Devuan SD card images
+
+This repository is a bunch of scripts to build SD card images that various [single-board computers](https://en.wikipedia.org/wiki/Single-board_computer) (SBC) can boot. Emphasis is on pureness; pure Debian and pure mainline U-boot.
+
+## Pre-built images
+
+Pre-built images ready for download are availble at [sd-card-images.johang.se](https://sd-card-images.johang.se).
+
+## Usage
+
+The generated SD card images are made up of two separate images:
+
+- **boot-BOARD.bin**: Boot image that contains partition table, U-Boot and chip-specific code. The boot image will only work on the board it's built for. The filename indicates which board it's built for.
+- **debian-ARCH-VERSION-PASSWORD.bin**: Debian ext4 root filesystem image that contains a complete Debian installation, including kernel, initrd and device tree. This Debian image is generic and will work on all chips and boards with the CPU architecture it's built for. The filename indicates Debian version, CPU architecture and default root password.
+
+These two images are the concatenated to a single image, which is then written to SD card, for example like this:
+
+    $ zcat boot-raspberrypi_3b.bin.gz debian-buster-arm64-XXXXXX.bin.gz > sd-card.img
+    # dd if=sd-card.img of=/dev/sdXXX
+
+### Build your own Devuan boot image
+
+#### To build a boot image for Raspberry Pi 3 B:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm -v /tmp/sd-images:/artifacts sd-images build-boot raspberrypi_3b bcm2837 rpi_3_defconfig aarch64-linux-gnu
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+#### To build a boot image for Pine64 Rockpro64:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-boot ROCKPro64 rk3399 rockpro64-rk3399_defconfig aarch64-linux-gnu
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+#### To build a boot image for Sinovoip Banana Pi M2 Zero
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-boot banana_pi_m2_zero allwinner-h2+ bananapi_m2_zero_defconfig arm-linux-gnueabihf
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+### Build your own Debian ext4 root filesystem image
+
+#### To build a Devuan ext4 root filesystem image for arm64:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  --privileged \
+  devuan/sd-images \
+  build-debian devuan arm64 daedalus
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+#### To build a Devuan ext4 root filesystem image for armhf:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  --privileged \
+  devuan/sd-images \
+  build-debian devuan armhf daedalus
+```
+
+The image will end up in /tmp/sd-images on the host.

--- a/debians-arm.csv
+++ b/debians-arm.csv
@@ -9,6 +9,16 @@ debian,sid,armhf,"Debian unstable (""sid"")",False
 debian,sid,arm64,"Debian unstable (""sid"")",False
 debian,experimental,armhf,"Debian experimental (""rc-buggy"")",True
 debian,experimental,arm64,"Debian experimental (""rc-buggy"")",True
+devuan,ceres,armhf,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,ceres,arm64,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,beowulf,armhf,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,beowulf,arm64,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,chimaera,armhf,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,chimaera,arm64,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,daedalus,armhf,"Devuan stable/5.0 (""daedalus"")",False
+devuan,daedalus,arm64,"Devuan stable/5.0 (""daedalus"")",False
+devuan,excalibur,armhf,"Devuan testing/6.0 (""excalibur"")",False
+devuan,excalibur,arm64,"Devuan testing/6.0 (""excalibur"")",False
 ubuntu,focal,armhf,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,focal,arm64,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,jammy,armhf,"Ubuntu 22.04 LTS (""jammy"")",False

--- a/debians-x86.csv
+++ b/debians-x86.csv
@@ -9,6 +9,16 @@ debian,sid,i386,"Debian unstable (""sid"")",False
 debian,sid,amd64,"Debian unstable (""sid"")",False
 debian,experimental,i386,"Debian experimental (""rc-buggy"")",True
 debian,experimental,amd64,"Debian experimental (""rc-buggy"")",True
+devuan,ceres,i386,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,ceres,amd64,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,beowulf,i386,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,beowulf,amd64,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,chimaera,i386,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,chimaera,amd64,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,daedalus,i386,"Devuan stable/5.0 (""daedalus"")",False
+devuan,daedalus,amd64,"Devuan stable/5.0 (""daedalus"")",False
+devuan,excalibur,i386,"Devuan testing/6.0 (""excalibur"")",False
+devuan,excalibur,amd64,"Devuan testing/6.0 (""excalibur"")",False
 ubuntu,focal,i386,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,focal,amd64,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,jammy,i386,"Ubuntu 22.04 LTS (""jammy"")",False

--- a/metascripts/rebuild-debian-csv
+++ b/metascripts/rebuild-debian-csv
@@ -21,14 +21,26 @@ class Release:
         for line in fileobj:
             line = line.decode('utf-8').strip()
             # Header of "Release" finishes at:
-            #   "MD5Sum:"	Debian/Ubuntu
-            if line == "MD5Sum:":
+            #   "MD5Sum:" in Debian/Ubuntu
+            #   "SHA256:" in Devuan
+            if line == "MD5Sum:" or line == "SHA256:":
                 break
 
             k, v = line.split(": ", 1)
             params[k] = v
 
-        self.label = params.get("Label")
+        # In Release files,
+        #    e.g. https://ftp.debian.org/debian/dists/stable/Release
+        # "Origin" is Debian/Ubuntu/Devuan as expected.
+        # "Origin" = "Label" for Debian and Ubuntu, not always for Devuan.
+        # "Label" is "Debian"/"Ubuntu" for Debian/Ubuntu.
+        # "Label" is "Devuan" or "Master" for Devuan.
+        # "Label" of "Master" has no equivalent in Debian/Ubuntu.
+        #
+        # Where this program uses "label" it really wants "origin".
+        self.origin = params.get("Origin")
+        self.label = self.origin
+
         self.suite = params.get("Suite")
         self.version = params.get("Version")
         self.codename = params.get("Codename")
@@ -86,16 +98,29 @@ class Release:
             return date.today() - release_date
 
     def is_relevant(self):
-        if self.label not in ("Debian", "Ubuntu", ):
+        if self.label not in ("Debian", "Ubuntu", "Devuan", ):
             return False
 
-        bl1 = ("oldoldstable", "devel", )
-        if self.suite in bl1:
-            return False
+        if self.label == "Debian" or self.label == "Ubuntu":
+            bl1 = ("oldoldstable", "devel", )
+            if self.suite in bl1:
+                return False
 
-        bl2 = ("-updates", "-backports", "-security", "-proposed", "-sloppy", )
-        if any(self.suite.endswith(suffix) for suffix in bl2):
-            return False
+            bl2 = ("-updates", "-backports", "-security", "-proposed", "-sloppy", )
+            if any(self.suite.endswith(suffix) for suffix in bl2):
+                return False
+
+        if self.label == "Devuan":
+            # "oldoldstable" is maintained in Devuan.
+            # These are no longer maintained.
+            bl_ = ("jessie", "ascii", )
+            if self.suite in bl_:
+                return False
+
+            # For fine-grained control:
+            bl_ = ("-backports", "-security", "-proposed-updates", )
+            if any(self.suite.endswith(suffix) for suffix in bl_):
+                return False
 
         if self.label == "Ubuntu":
             if self.is_lts():
@@ -109,6 +134,8 @@ class Release:
         if self.label == "Debian" and self.suite == "experimental":
             return True
         if self.label == "Ubuntu" and self.age() < timedelta(days=0):
+            return True
+        if self.label == "Devuan" and self.suite == "experimental":
             return True
 
         return False
@@ -249,6 +276,7 @@ def write_csv(filename, releases, archs):
 
         for r in releases:
             if not r.is_relevant():
+                logger.debug("Discarding as not relevant: %s ", repr(r))
                 continue
 
             for arch in archs:
@@ -275,7 +303,9 @@ if __name__ == "__main__":
     assert len(debianreleases) > 0
     ubuntureleases = set(get_dist_releases("http://ftp.ubuntu.com/ubuntu"))
     assert len(ubuntureleases) > 0
-    releases = list(sorted(debianreleases | ubuntureleases))
+    devuanreleases = set(get_dist_releases("http://deb.devuan.org/merged"))
+    assert len(devuanreleases) > 0
+    releases = list(sorted(debianreleases | ubuntureleases | devuanreleases))
     assert len(releases) > 0
     logger.info("Found %d releases", len(releases))
 

--- a/metascripts/rebuild-debian-csv
+++ b/metascripts/rebuild-debian-csv
@@ -19,11 +19,13 @@ class Release:
     def __init__(self, fileobj):
         params = {}
         for line in fileobj:
-            line = line.decode("utf-8")
-            if line.startswith(" ") or ": " not in line:
-                continue
+            line = line.decode('utf-8').strip()
+            # Header of "Release" finishes at:
+            #   "MD5Sum:"	Debian/Ubuntu
+            if line == "MD5Sum:":
+                break
 
-            k, v = line.strip().split(": ", 1)
+            k, v = line.split(": ", 1)
             params[k] = v
 
         self.label = params.get("Label")
@@ -112,6 +114,13 @@ class Release:
         return False
 
 
+"""
+# Note: get_releases(url) is deprecated because it can not work with Devuan.
+# Instead, use get_dist_releases(url).
+# 
+# get_releases(url) requires the file ls-lR.gz to be present.
+# This is not available in Devuan.
+#
 def get_releases(url):
     dirlinepattern = re.compile(
         r"\.(/dists/[\w\-]+):"
@@ -172,6 +181,65 @@ def get_releases(url):
                             yield Release(u)
                     except urllib.error.URLError as e:
                         logger.warning("Failed to download %s: %s", relurl, e)
+"""
+
+
+def get_dist_releases(url):
+
+    from lxml import html
+
+    # Open the web page listurl and use an xpath to extract the dist names.
+    listurl = url + "/dists/"
+
+    try:
+        tree = html.fromstring(urllib.request.urlopen(listurl).read())
+        logger.debug("Downloaded %s", listurl)
+    except urllib.error.URLError as e:
+        logger.warning("Failed to download %s: %s", listurl, e)
+    else:
+        # Extract dist names from the web links.
+        """
+        Finds <a href="{debiandir}"> in the web page.
+
+        Using Xpath 1.0:
+          matches: buster/, daedalus/, noble/, oldstable, stable/, unstable/
+          does not match: ../, /debian/, daedalus-updates/, 6.0/
+
+
+        The chosen xpath:
+
+            dist_path = "//a[contains(@href,'/') \
+                                      and not(starts-with(@href,'/')) \
+                                      and not(contains(@href,'-')) \
+                                      and not(contains(@href,'.')) \
+                                     ]/@href"
+
+        will select only hrefs which are:
+            not, e.g., /debian/         not(starts-with(@href,'/'))
+            directories                 contains(@href,'/')
+            codenames                   not(contains(@href,'-'))
+            not numbers or ../          not(contains(@href,'.'))
+
+        This excludes all "-updates", "-backports", "-security", "-proposed", etc.
+        """
+        dist_path = "//a[contains(@href,'/') \
+                         and not(starts-with(@href,'/')) \
+                         and not(contains(@href,'-')) \
+                         and not(contains(@href,'.')) \
+                        ]/@href"
+
+        dist_names = tree.xpath(dist_path)
+
+        for debiandir in dist_names:
+            relurl = listurl + debiandir + "Release"
+
+            try:
+                with urllib.request.urlopen(relurl) as u:
+                    logger.debug("Downloaded %s", relurl)
+
+                    yield Release(u)
+            except urllib.error.URLError as e:
+                logger.warning("Failed to download %s: %s", relurl, e)
 
 
 def write_csv(filename, releases, archs):
@@ -203,9 +271,9 @@ def write_csv(filename, releases, archs):
 
 if __name__ == "__main__":
     logger.info("Downloading releases...")
-    debianreleases = set(get_releases("http://ftp.debian.org/debian"))
+    debianreleases = set(get_dist_releases("http://ftp.debian.org/debian"))
     assert len(debianreleases) > 0
-    ubuntureleases = set(get_releases("http://ftp.ubuntu.com/ubuntu"))
+    ubuntureleases = set(get_dist_releases("http://ftp.ubuntu.com/ubuntu"))
     assert len(ubuntureleases) > 0
     releases = list(sorted(debianreleases | ubuntureleases))
     assert len(releases) > 0

--- a/scripts/build-boot-rpi
+++ b/scripts/build-boot-rpi
@@ -73,7 +73,8 @@ sed -i -e "s/BOOT_UART=0/BOOT_UART=1/" bootcode.bin
 
 # Create empty FAT partition
 rm -f vfat.img
-fallocate -l 28MiB vfat.img
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 28MiB vfat.img || truncate --size 28MiB vfat.img
 mkfs.vfat vfat.img
 
 # Copy boot files to FAT partition

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -197,7 +197,8 @@ mv debian/tmp/versions.csv versions.csv
 # >>> ((3800000000 - 32 * 1024 * 1024) // (1024 * 1024)) * (1024 * 1024)
 # 3765436416
 rm -f ext4.img
-fallocate -l 3765436416 ext4.img
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 3765436416 ext4.img || truncate --size=3765436416 ext4.img
 mkfs.ext4 -d debian ext4.img
 pigz ext4.img
 

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -44,6 +44,31 @@ ubuntu-armhf|ubuntu-arm64)
 	KERNEL_URL=http://packages.ubuntu.com/"${DIST}"/"${KERNEL}"
 	SCRIPT=/usr/share/debootstrap/scripts/gutsy
 	;;
+devuan-armhf)
+	KERNEL=linux-image-armmp
+	URL=http://deb.devuan.org/merged
+	# 2024-05-01 pkginfo.devuan.org does not have info for armhf.
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
+devuan-arm64)
+	KERNEL=linux-image-arm64
+	URL=http://deb.devuan.org/merged
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
+devuan-i386)
+	KERNEL=linux-image-686
+	URL=http://deb.devuan.org/merged
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
+devuan-amd64)
+	KERNEL=linux-image-amd64
+	URL=http://deb.devuan.org/merged
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
 *)
 	echo "Can't decide kernel package for \"${ARCH}\""
 	exit 1
@@ -67,6 +92,8 @@ trap 'rm -rf "${TMP}"' EXIT INT TERM
 cd "${TMP}"
 
 # Build a Debian root filesystem (first stage)
+case ${OS} in
+debian | ubuntu)
 debootstrap \
   --arch="${ARCH}" \
   --verbose \
@@ -84,6 +111,28 @@ nano \
   debian \
   "${URL}" \
   "${SCRIPT}"
+	;;
+devuan)
+debootstrap \
+  --arch="${ARCH}" \
+  --verbose \
+  --variant=minbase \
+  --foreign \
+  --include=\
+netbase,\
+net-tools,\
+sysvinit,\
+u-boot-tools,\
+initramfs-tools,\
+openssh-server,\
+nano,\
+vim-tiny \
+  "${TARGET}" \
+  debian \
+  "${URL}" \
+  "${SCRIPT}"
+	;;
+esac
 
 # Randomly generated root password
 PASSWORD="${PASSWORD_OVERRIDE:-$(pwgen -B -A 6 1)}"
@@ -134,6 +183,23 @@ deb http://ports.ubuntu.com/ubuntu-ports ${DIST}-security main universe
 deb-src http://ports.ubuntu.com/ubuntu-ports ${DIST}-security main universe
 EOF
 	;;
+devuan-*-ceres | devuan-*-unstable)
+	# https://pkginfo.devuan.org/sources.list.txt
+	tee debian/tmp/sources.list <<-EOF
+deb http://deb.devuan.org/merged ${DIST} main
+deb-src http://deb.devuan.org/merged ${DIST} main
+EOF
+	;;
+devuan-*)
+	tee debian/tmp/sources.list <<-EOF
+deb http://deb.devuan.org/merged ${DIST} main
+deb-src http://deb.devuan.org/merged ${DIST} main
+deb http://deb.devuan.org/merged ${DIST}-updates main
+deb-src http://deb.devuan.org/merged ${DIST}-updates main
+deb http://deb.devuan.org/merged ${DIST}-security main
+deb-src http://deb.devuan.org/merged ${DIST}-security main
+EOF
+	;;
 esac
 
 case "${OS}-${ARCH}-${DIST}" in
@@ -156,7 +222,10 @@ cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files-${ARCH}/* debian
 cp -v /usr/bin/qemu-*-static debian/usr/bin || :
 
 # Build a Debian root filesystem (second stage)
-chroot debian /bin/sh -ex <<- EOF
+case "${OS}" in
+debian | ubuntu)
+	# Build a Debian root filesystem (second stage)
+chroot debian /bin/sh -ex <<-EOF
 /debootstrap/debootstrap --second-stage
 /bin/mv /tmp/sources.list /etc/apt/sources.list
 /bin/mv /tmp/priority-experimental /etc/apt/preferences.d/priority-experimental || :
@@ -176,6 +245,28 @@ echo "kernel-url,${KERNEL_URL}\n" >> /tmp/versions.csv
 /bin/echo "root:${PASSWORD}" | /usr/sbin/chpasswd
 /bin/sed -i "s/#*\s*PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config
 EOF
+	;;
+devuan)
+	# Build a Devuan root filesystem (second stage)
+chroot debian /bin/sh -ex <<-EOF
+/debootstrap/debootstrap --second-stage
+/bin/mv /tmp/sources.list /etc/apt/sources.list
+# /usr/bin/apt-key add /etc/apt/trusted.gpg.d/devuan_key.gpg
+/usr/bin/apt-get update
+/usr/bin/apt-get -y upgrade
+/usr/bin/apt-get -y --no-install-recommends "${KERNELSUITE}" install "${KERNEL}"
+/usr/bin/apt-get -y install connman || :
+/usr/bin/apt-get -y install openntpd || :
+/usr/bin/apt-get clean
+/bin/rm -rf /var/lib/apt/lists/*
+echo "kernel-url,${KERNEL_URL}\n" >> /tmp/versions.csv
+/usr/bin/dpkg-query --showformat='kernel,\${Version}\n' --show "${KERNEL}" > /tmp/versions.csv
+/bin/rm -f /var/log/*.log
+/bin/echo "root:${PASSWORD}" | /usr/sbin/chpasswd
+/bin/sed -i "s/#*\s*PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config
+EOF
+	;;
+esac
 
 # Remove ARM emulation stuff again
 rm -v debian/usr/bin/qemu-*-static || :
@@ -186,7 +277,14 @@ cp -rv --preserve=mode ../2nd-stage-files/post-2nd-stage-files/* debian
 echo "${OS}" > debian/etc/hostname
 
 # Set resolv.conf
-ln -sf /run/systemd/resolve/stub-resolv.conf debian/etc/resolv.conf
+case "${OS}" in
+debian | ubuntu)
+	ln -sf /run/systemd/resolve/stub-resolv.conf debian/etc/resolv.conf
+	;;
+devuan)
+	ln -sf /run/connman/resolv.conf debian/etc/resolv.conf
+	;;
+esac
 
 # List all files
 find debian ! -type d -printf "/%P\n" | sort > files.txt

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -14,7 +14,8 @@ if [ $IMAGE_SIZE -lt 1000000000 ]; then
   exit 1
 fi
 rm -f "${IMAGE}"
-fallocate -v -l "${IMAGE_SIZE}" "${IMAGE}" # 3,800,000,000 bytes
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -v -l "${IMAGE_SIZE}" "${IMAGE}" || truncate --size "${IMAGE_SIZE}" "${IMAGE}" # 3,800,000,000 bytes
 
 parted -s "${IMAGE}" mklabel msdos
 parted -s "${IMAGE}" mkpart primary fat32 -- 4MiB 32MiB # 28 MiB (29,360,128 bytes)
@@ -23,7 +24,8 @@ parted -s "${IMAGE}" set 2 boot on
 
 # Create empty FAT partition
 rm -f vfat.img
-fallocate -l 28MiB vfat.img
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 28MiB vfat.img || truncate --size 28MiB vfat.img
 mkfs.vfat vfat.img
 
 # Leave a friendly note about this partition

--- a/test/qemu.sh
+++ b/test/qemu.sh
@@ -31,7 +31,8 @@ LOOP1=$(losetup -f -P --show image.bin) && {
 }
 
 # Assume 8GB virtual disk
-fallocate -l 8GB image.bin
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 8GB image.bin || truncate --size 8GB image.bin
 
 # Extend second partition
 parted -s -a opt image.bin "resizepart 2 100%"


### PR DESCRIPTION
rebuild-debian-csv now gets codenames from the Debian,
Ubuntu and Devuan repository web pages, because
Devuan does not have an ls-lR.gz file.

Adds Dockerfile.devuan to build from a Devuan image.

README_devuan.md extends README.md.

Fix for when fallocate fails on (git CI) COW filesystems.
