### PR TITLE
Add support for Banana PI CM4IO

### DIFF
--- a/boards.csv
+++ b/boards.csv
@@ -194,6 +194,7 @@ radxa_zero,Zero,Radxa,meson-g12a,radxa-zero_defconfig,aarch64-linux-gnu,meson-g1
 amlogic_u200,U200,Amlogic,meson-g12a,u200_defconfig,aarch64-linux-gnu,meson-g12a-u200
 
 banana_pi_m2s,Banana Pi M2S,Sinovoip,meson-g12b,bananapi-m2s_defconfig,aarch64-linux-gnu,meson-g12b-a311d-bananapi-m2s
+banana_pi_cm4io,Banana Pi CM4IO,Sinovoip,meson-g12b,bananapi-cm4-cm4io_defconfig,aarch64-linux-gnu,meson-g12b-bananapi-cm4io
 khadas_vim3,VIM3,Khadas,meson-g12b,khadas-vim3_defconfig,aarch64-linux-gnu,meson-g12b-a311d-khadas-vim3
 beelink_gt_king_x,GT-King X,Beelink,meson-g12b,beelink-gsking-x_defconfig,aarch64-linux-gnu,meson-g12b-gsking-x
 beelink_gt_king,GT-King,Beelink,meson-g12b,beelink-gtking_defconfig,aarch64-linux-gnu,meson-g12b-gtking

--- a/docs/_boards/banana_pi_cm4io.md
+++ b/docs/_boards/banana_pi_cm4io.md
@@ -1,0 +1,13 @@
+---
+layout: board
+title: Banana Pi CM4IO SD card images
+description: "Minimal, pure and up-to-date vanilla Debian/Ubuntu arm64 SD card images for Banana Pi CM4IO by Sinovoip, SoC: Amlogic S922X/A311D, CPU ISA: armv8"
+board_id: banana_pi_cm4io
+board_dtb_name: meson-g12b-bananapi-cm4-cm4io
+board_name: Banana Pi CM4IO
+board_maker_name: Sinovoip
+board_soc_name: Amlogic S922X/A311D
+board_cpu_name: ARM Cortex A73/A53 (armv8)
+board_cpu_arch_isa: armv8
+board_cpu_arch_debian: arm64
+---

--- a/scripts/build-boot-meson
+++ b/scripts/build-boot-meson
@@ -44,6 +44,9 @@ libretech_s912_pc*)
 beelink_gt_king*)
 	BOARD=beelink-s922x
 	;;
+banana_pi_cm4io)
+        BOARD=bananapi-cm4io
+        ;;
 *)
 	# X_Y_defconfig -> x-y
 	BOARD=`echo "${DEFCONFIG%_defconfig}" | tr _ -`


### PR DESCRIPTION
Add support for Banana PI CM4 IO board
I tested the firmware with trixie using:
<code>
docker run --rm -v /tmp/sd-images:/artifacts sd-images build-boot banana_pi_cm4io meson-g12b bananapi-cm4-cm4io_defconfig aarch64-linux-gnu
</code>

kernel is too old with bookworm and it works badly