### PR TITLE
feat: Generate ssh host keys on first boot

### DIFF
--- a/2nd-stage-files/pre-2nd-stage-files/etc/systemd/system/generate-ssh-host-keys.service
+++ b/2nd-stage-files/pre-2nd-stage-files/etc/systemd/system/generate-ssh-host-keys.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Generate SSH host keys on first boot
+ConditionPathExistsGlob=!/etc/ssh/ssh_host_*_key
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/dpkg-reconfigure -f noninteractive openssh-server
+
+[Install]
+RequiredBy=multi-user.target

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -172,6 +172,7 @@ echo "kernel-url,${KERNEL_URL}\n" >> /tmp/versions.csv
 /usr/bin/systemctl enable systemd-networkd.service
 /usr/bin/systemctl enable systemd-resolved.service
 /usr/bin/systemctl enable systemd-timesyncd.service
+/usr/bin/systemctl enable generate-ssh-host-keys.service
 /bin/rm -f /var/log/*.log
 /bin/echo "root:${PASSWORD}" | /usr/sbin/chpasswd
 /bin/sed -i "s/#*\s*PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config
@@ -179,6 +180,9 @@ EOF
 
 # Remove ARM emulation stuff again
 rm -v debian/usr/bin/qemu-*-static || :
+
+# Remove ssh host keys, they will be generated on first boot by generate-ssh-host-keys.service
+rm -v debian/etc/ssh/ssh_host_*_key* || :
 
 cp -rv --preserve=mode ../2nd-stage-files/post-2nd-stage-files/* debian
 


### PR DESCRIPTION
This change removes the keys generated by dpkg/debootstrap during configure phase and adds a systemd unit that runs dpkg-reconfigure openssh-server only if ssh host keys are not found. This ensures that every image burned to sd card gets it's own set of ssh host keys, improving the security posture.

Fixes https://github.com/johang/sd-card-images/issues/62