### PR TITLE
Add support for Radxa Rock 5C board

### DIFF
--- a/boards.csv
+++ b/boards.csv
@@ -78,6 +78,7 @@ orangepi_5_plus,Orange Pi 5 Plus,Xunlong,rk3588,orangepi-5-plus-rk3588_defconfig
 quartzpro64,QuartzPro64,PINE64,rk3588,quartzpro64-rk3588_defconfig,aarch64-linux-gnu,rk3588-quartzpro64
 rock_5_itx,ROCK 5 ITX,Radxa,rk3588,rock-5-itx-rk3588_defconfig,aarch64-linux-gnu,rk3588-rock-5-itx
 rock_5b,ROCK 5B,Radxa,rk3588,rock5b-rk3588_defconfig,aarch64-linux-gnu,rk3588-rock-5b
+rock_5c,ROCK 5C,Radxa,rk3588,rock-5c-rk3588s_defconfig,aarch64-linux-gnu,rk3588s-rock-5c
 orangepi_5,Orange Pi 5,Xunlong,rk3588,orangepi-5-rk3588s_defconfig,aarch64-linux-gnu,rk3588s-orangepi-5
 rock_5a,ROCK 5A,Radxa,rk3588,rock5a-rk3588s_defconfig,aarch64-linux-gnu,rk3588s-rock-5a
 cool_pi_4b,Cool Pi 4B,Yanyi Tech,rk3588,coolpi-4b-rk3588s_defconfig,aarch64-linux-gnu,rk3588s-coolpi-4b

--- a/docs/_boards/rock_5c.md
+++ b/docs/_boards/rock_5c.md
@@ -1,0 +1,13 @@
+---
+layout: board
+title: ROCK 5C SD card images
+description: "Minimal, pure and up-to-date vanilla Debian/Ubuntu arm64 SD card images for ROCK 5C by Radxa, SoC: Rockchip RK3588S2, CPU ISA: armv8"
+board_id: rock_5c
+board_dtb_name: rk3588s-rock-5c
+board_name: ROCK 5C
+board_maker_name: Radxa
+board_soc_name: Rockchip RK3588S2
+board_cpu_name: ARM Cortex A76/A55 (armv8)
+board_cpu_arch_isa: armv8
+board_cpu_arch_debian: arm64
+---

--- a/docs/_boards/rock_5c.md
+++ b/docs/_boards/rock_5c.md
@@ -1,12 +1,12 @@
 ---
 layout: board
 title: ROCK 5C SD card images
-description: "Minimal, pure and up-to-date vanilla Debian/Ubuntu arm64 SD card images for ROCK 5C by Radxa, SoC: Rockchip RK3588S2, CPU ISA: armv8"
+description: "Minimal, pure and up-to-date vanilla Debian/Ubuntu arm64 SD card images for ROCK 5C by Radxa, SoC: Rockchip RK3588, CPU ISA: armv8"
 board_id: rock_5c
 board_dtb_name: rk3588s-rock-5c
 board_name: ROCK 5C
 board_maker_name: Radxa
-board_soc_name: Rockchip RK3588S2
+board_soc_name: Rockchip RK3588
 board_cpu_name: ARM Cortex A76/A55 (armv8)
 board_cpu_arch_isa: armv8
 board_cpu_arch_debian: arm64


### PR DESCRIPTION
Hi,

Can you add the Radxa Rock 5C board?

Tested and confirmed to work using:
* boot-rock_5c.bin.gz (self build using Docker)
* debian-trixie-arm64-ohd7ae.bin.gz

HDMI support is not present in trixie's kernel, just like with the Orange Pi 5 image.
But it works great for server purposes.


Kind regards,
Sander