### PR TITLE
[RFC] Add i.MX8 support

### DIFF
--- a/boards.csv
+++ b/boards.csv
@@ -257,3 +257,5 @@ qemu_arm_virt,QEMU arm virt,QEMU,qemu-arm,qemu_arm_defconfig,arm-linux-gnueabihf
 qemu_aarch64_virt,QEMU aarch64 virt,QEMU,qemu-aarch64,qemu_arm64_defconfig,aarch64-linux-gnu,N/A
 qemu_x86_virt,QEMU x86 virt,QEMU,qemu-x86,qemu-x86_defconfig,i686-linux-gnu,N/A
 qemu_x86_64_virt,QEMU x86_64 virt,QEMU,qemu-x86_64,qemu-x86_64_defconfig,x86_64-linux-gnu,N/A
+
+olimex_imx8_som_evb,Olimex i.MX8MP-SOM-EVB,Olimex,imx8,imx8mp_olimex_som_evb_defconfig,aarch64-linux-gnu,imx8mp-olimex-som-evb.dts

--- a/chips.csv
+++ b/chips.csv
@@ -48,3 +48,6 @@ qemu-arm,arm,QEMU,ARM Cortex A15,armv7,armhf
 qemu-aarch64,aarch64,QEMU,ARM Cortex A53,armv8,arm64
 qemu-x86_64,x86_64,QEMU,x86 qemu64,x86-64,amd64
 qemu-x86,x86,QEMU,x86 qemu32,x86,i386
+
+imx6,i.MX6,NXP/Freescale,ARM Cortex A9,armv7,armhf
+imx8,i.MX8,NXP/Freescale,ARM Cortex A53,armv8,arm64

--- a/patches/u-boot/0005-imx-Add-support-for-Olimex-i.MX8MP-SOM-EVB-board.patch
+++ b/patches/u-boot/0005-imx-Add-support-for-Olimex-i.MX8MP-SOM-EVB-board.patch
@@ -1,0 +1,3648 @@
+From d186c2f34c07b6dd9a31eb4372f79c29fbcd2e65 Mon Sep 17 00:00:00 2001
+From: Zoltan HERPAI <wigyori@uid0.hu>
+Date: Sat, 22 Aug 2026 22:52:13 +0000
+Subject: [PATCH] imx: Add support for Olimex i.MX8MP-SOM-EVB board
+
+This adds support for the Olimex i.MX8MP SoM and the matching
+baseboard EVB.
+
+Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>
+---
+ arch/arm/dts/Makefile                         |    1 +
+ .../arm/dts/imx8mp-olimex-som-evb-u-boot.dtsi |  139 ++
+ arch/arm/mach-imx/imx8m/Kconfig               |   17 +
+ board/olimex/imx8mp_olimex_som_evb/Kconfig    |   15 +
+ .../olimex/imx8mp_olimex_som_evb/MAINTAINERS  |    6 +
+ board/olimex/imx8mp_olimex_som_evb/Makefile   |   12 +
+ .../imx8mp_olimex_som_evb.c                   |   40 +
+ .../imx8mp_olimex_som_evb.env                 |   58 +
+ .../imximage-8mp-lpddr4.cfg                   |    9 +
+ .../imx8mp_olimex_som_evb/lpddr4_timing.c     | 2048 +++++++++++++++++
+ board/olimex/imx8mp_olimex_som_evb/spl.c      |  121 +
+ configs/imx8mp_olimex_som_evb_defconfig       |  165 ++
+ .../arm64/freescale/imx8mp-olimex-som-evb.dts |  843 +++++++
+ include/configs/imx8mp_olimex_som_evb.h       |   32 +
+ 14 files changed, 3506 insertions(+)
+ create mode 100644 arch/arm/dts/imx8mp-olimex-som-evb-u-boot.dtsi
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/Kconfig
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/MAINTAINERS
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/Makefile
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.c
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.env
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/imximage-8mp-lpddr4.cfg
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/lpddr4_timing.c
+ create mode 100644 board/olimex/imx8mp_olimex_som_evb/spl.c
+ create mode 100644 configs/imx8mp_olimex_som_evb_defconfig
+ create mode 100644 dts/upstream/src/arm64/freescale/imx8mp-olimex-som-evb.dts
+ create mode 100644 include/configs/imx8mp_olimex_som_evb.h
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index a02dad22..3c6517aa 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -853,6 +853,7 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
+ 	imx8mm-data-modul-edm-sbc.dtb \
+ 	imx8mm-mx8menlo.dtb \
+ 	imx8mq-cm.dtb \
++	imx8mp-olimex-som-evb.dtb \
+ 	imx8mp-data-modul-edm-sbc.dtb \
+ 	imx8mp-dhcom-som-overlay-rev100.dtbo \
+ 	imx8mp-dhcom-som-overlay-eth1xfast.dtbo \
+diff --git a/arch/arm/dts/imx8mp-olimex-som-evb-u-boot.dtsi b/arch/arm/dts/imx8mp-olimex-som-evb-u-boot.dtsi
+new file mode 100644
+index 00000000..369e5624
+--- /dev/null
++++ b/arch/arm/dts/imx8mp-olimex-som-evb-u-boot.dtsi
+@@ -0,0 +1,139 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2019, 2021 NXP
++ */
++
++#include "imx8mp-u-boot.dtsi"
++
++/ {
++	wdt-reboot {
++		compatible = "wdt-reboot";
++		wdt = <&wdog1>;
++		bootph-pre-ram;
++	};
++};
++
++&pinctrl_i2c1 {
++	bootph-all;
++};
++
++&pinctrl_pmic {
++	bootph-all;
++};
++
++&pmic {
++	bootph-all;
++};
++
++&{/soc@0/bus@30800000/i2c@30a20000/pmic@25/regulators} {
++	bootph-all;
++};
++
++&reg_usdhc2_vmmc {
++	u-boot,off-on-delay-us = <20000>;
++};
++
++&reg_usdhc2_vmmc {
++	bootph-pre-ram;
++};
++
++&pinctrl_uart2 {
++	bootph-pre-ram;
++};
++
++&pinctrl_usdhc2_gpio {
++	bootph-pre-ram;
++};
++
++&pinctrl_usdhc2 {
++	bootph-pre-ram;
++};
++
++&pinctrl_usdhc3 {
++	bootph-pre-ram;
++};
++
++&pinctrl_wdog {
++	bootph-pre-ram;
++};
++
++&gpio1 {
++	bootph-pre-ram;
++};
++
++&gpio2 {
++	bootph-pre-ram;
++};
++
++&gpio3 {
++	bootph-pre-ram;
++};
++
++&gpio4 {
++	bootph-pre-ram;
++};
++
++&gpio5 {
++	bootph-pre-ram;
++};
++
++&uart2 {
++	bootph-pre-ram;
++};
++
++&i2c1 {
++	bootph-all;
++};
++
++&i2c2 {
++	bootph-pre-ram;
++};
++
++&i2c3 {
++	bootph-pre-ram;
++};
++
++&i2c4 {
++	bootph-pre-ram;
++};
++
++&i2c5 {
++	bootph-pre-ram;
++};
++
++&i2c6 {
++	bootph-pre-ram;
++};
++
++&usb_dwc3_0 {
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usb3_0 {
++	status = "okay";
++};
++
++&usb3_phy0 {
++	status = "okay";
++};
++
++&usdhc1 {
++	bootph-pre-ram;
++};
++
++&usdhc2 {
++	bootph-pre-ram;
++	sd-uhs-sdr104;
++	sd-uhs-ddr50;
++};
++
++&usdhc3 {
++	bootph-pre-ram;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++};
++
++&wdog1 {
++	bootph-pre-ram;
++};
+diff --git a/arch/arm/mach-imx/imx8m/Kconfig b/arch/arm/mach-imx/imx8m/Kconfig
+index c03c4e72..4563170e 100644
+--- a/arch/arm/mach-imx/imx8m/Kconfig
++++ b/arch/arm/mach-imx/imx8m/Kconfig
+@@ -298,6 +298,22 @@ config TARGET_IMX8MP_NAVQP
+ 	select SUPPORT_SPL
+ 	imply OF_UPSTREAM
+ 
++config TARGET_IMX8MP_OLIMEX_SOM_EVB
++	bool "Olimex i.MX8MP-SOM-EVB LPDDR4 board"
++	select IMX8MP
++	select SUPPORT_SPL
++	select IMX8M_LPDDR4
++	select FSL_CAAM
++	select ARCH_MISC_INIT
++	select SPL_CRYPTO if SPL
++	select CMD_REMOTEPROC
++	select REMOTEPROC_IMX
++	select REGMAP
++	select SYSCON
++	imply OF_UPSTREAM
++	imply BOOTSTD_FULL
++	imply BOOTSTD_BOOTCOMMAND
++
+ config TARGET_IMX8MP_VENICE
+ 	bool "Support Gateworks Venice iMX8M Plus module"
+ 	select IMX8MP
+@@ -470,6 +486,7 @@ source "board/kontron/sl-mx8mm/Kconfig"
+ source "board/menlo/mx8menlo/Kconfig"
+ source "board/msc/sm2s_imx8mp/Kconfig"
+ source "board/mntre/imx8mq_reform2/Kconfig"
++source "board/olimex/imx8mp_olimex_som_evb/Kconfig"
+ source "board/phytec/imx8mp-libra-fpsc/Kconfig"
+ source "board/phytec/phycore_imx8mm/Kconfig"
+ source "board/phytec/phycore_imx8mp/Kconfig"
+diff --git a/board/olimex/imx8mp_olimex_som_evb/Kconfig b/board/olimex/imx8mp_olimex_som_evb/Kconfig
+new file mode 100644
+index 00000000..082d2142
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/Kconfig
+@@ -0,0 +1,15 @@
++if TARGET_IMX8MP_OLIMEX_SOM_EVB
++
++config SYS_BOARD
++	default "imx8mp_olimex_som_evb"
++
++config SYS_VENDOR
++	default "olimex"
++
++config SYS_CONFIG_NAME
++	default "imx8mp_olimex_som_evb"
++
++config IMX_CONFIG
++	default "board/olimex/imx8mp_olimex_som_evb/imximage-8mp-lpddr4.cfg"
++
++endif
+diff --git a/board/olimex/imx8mp_olimex_som_evb/MAINTAINERS b/board/olimex/imx8mp_olimex_som_evb/MAINTAINERS
+new file mode 100644
+index 00000000..85406bb9
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/MAINTAINERS
+@@ -0,0 +1,6 @@
++Olimex i.MX8MP-SOM-EVB BOARD
++M:	Zoltan HERPAI <wigyori@uid0.hu>
++S:	Maintained
++F:	board/olimex/imx8mp_olimex_som_evb/
++F:	include/configs/imx8mp_olimex_som_evb.h
++F:	configs/imx8mp_olimex_som_evb_defconfig
+diff --git a/board/olimex/imx8mp_olimex_som_evb/Makefile b/board/olimex/imx8mp_olimex_som_evb/Makefile
+new file mode 100644
+index 00000000..8246c952
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/Makefile
+@@ -0,0 +1,12 @@
++#
++# Copyright 2019 NXP
++#
++# SPDX-License-Identifier:      GPL-2.0+
++#
++
++obj-y += imx8mp_olimex_som_evb.o
++
++ifdef CONFIG_XPL_BUILD
++obj-y += spl.o
++obj-$(CONFIG_IMX8M_LPDDR4) += lpddr4_timing.o
++endif
+diff --git a/board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.c b/board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.c
+new file mode 100644
+index 00000000..9e716851
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.c
+@@ -0,0 +1,40 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2019 NXP
++ * Copyright 2026 Zoltan HERPAI <wigyori@uid0.hu>
++ */
++
++#include <config.h>
++#include <efi_loader.h>
++#include <env.h>
++#include <asm/arch/sys_proto.h>
++
++#if CONFIG_IS_ENABLED(EFI_HAVE_CAPSULE_SUPPORT)
++#define IMX_BOOT_IMAGE_GUID \
++	EFI_GUID(0x928b33bc, 0xe58b, 0x4247, 0x9f, 0x1d, \
++		 0x3b, 0xf1, 0xee, 0x1c, 0xda, 0xff)
++
++struct efi_fw_image fw_images[] = {
++	{
++		.image_type_id = IMX_BOOT_IMAGE_GUID,
++		.fw_name = u"IMX8MP-OLIMEX-SOM-EVB-RAW",
++		.image_index = 1,
++	},
++};
++
++struct efi_capsule_update_info update_info = {
++	.dfu_string = "mmc 2=flash-bin raw 0 0x2000 mmcpart 1",
++	.num_images = ARRAY_SIZE(fw_images),
++	.images = fw_images,
++};
++#endif /* EFI_HAVE_CAPSULE_SUPPORT */
++
++int board_late_init(void)
++{
++#ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
++	env_set("board_name", "OLIMEX-SOM-EVB");
++	env_set("board_rev", "iMX8MP");
++#endif
++
++	return 0;
++}
+diff --git a/board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.env b/board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.env
+new file mode 100644
+index 00000000..18cdf3da
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/imx8mp_olimex_som_evb.env
+@@ -0,0 +1,58 @@
++/* SPDX-License-Identifier: (GPL-2.0+ OR MIT) */
++
++boot_fdt=try
++boot_fit=no
++boot_targets=mmc1 mmc2
++bootm_size=0x10000000
++console=ttymxc1,115200 earlycon=ec_imx6q,0x30890000,115200
++fdt_addr_r=0x43000000
++fdt_addr=0x43000000
++fdtfile=CONFIG_DEFAULT_FDT_FILE
++image=Image
++ip_dyn=yes
++mmcdev=CONFIG_ENV_MMC_DEVICE_INDEX
++mmcpart=1
++mmcroot=/dev/mmcblk1p2 rootwait rw
++mmcautodetect=yes
++mmcargs=setenv bootargs ${jh_clk} ${mcore_clk} console=${console} root=${mmcroot}
++prepare_mcore=setenv mcore_clk clk-imx8mp.mcore_booted
++kernel_addr_r=CONFIG_SYS_LOAD_ADDR
++loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}
++loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr_r} ${fdtfile}
++mmcboot=echo Booting from mmc ...;
++	run mmcargs;
++	if test ${boot_fit} = yes || test ${boot_fit} = try; then
++		bootm ${loadaddr};
++	else
++		if run loadfdt; then
++			booti ${loadaddr} - ${fdt_addr_r};
++		else
++			echo WARN: Cannot load the DT;
++		fi;
++	fi;
++netargs=setenv bootargs ${jh_clk} ${mcore_clk} console=${console} root=/dev/nfs
++	ip=dhcp nfsroot=${serverip}:${nfsroot},v3,tcp
++netboot=echo Booting from net ...;
++	run netargs;
++	if test ${ip_dyn} = yes; then
++		setenv get_cmd dhcp;
++	else
++		setenv get_cmd tftp;
++	fi;
++	${get_cmd} ${loadaddr} ${image};
++	if test ${boot_fit} = yes || test ${boot_fit} = try; then
++		bootm ${loadaddr};
++	else
++		if ${get_cmd} ${fdt_addr_r} ${fdtfile}; then
++			booti ${loadaddr} - ${fdt_addr_r};
++		else
++			echo WARN: Cannot load the DT;
++		fi;
++	fi;
++bsp_bootcmd=echo Running BSP bootcmd ...;
++	mmc dev ${mmcdev};
++	if run loadimage; then
++		run mmcboot;
++	else
++		run netboot;
++	fi;
+diff --git a/board/olimex/imx8mp_olimex_som_evb/imximage-8mp-lpddr4.cfg b/board/olimex/imx8mp_olimex_som_evb/imximage-8mp-lpddr4.cfg
+new file mode 100644
+index 00000000..6dedf172
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/imximage-8mp-lpddr4.cfg
+@@ -0,0 +1,9 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright 2021 NXP
++ */
++
++
++ROM_VERSION	v2
++BOOT_FROM	sd
++LOADER		u-boot-spl-ddr.bin	0x920000
+diff --git a/board/olimex/imx8mp_olimex_som_evb/lpddr4_timing.c b/board/olimex/imx8mp_olimex_som_evb/lpddr4_timing.c
+new file mode 100644
+index 00000000..8c5306d5
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/lpddr4_timing.c
+@@ -0,0 +1,2048 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2019 NXP
++ */
++
++#include <linux/kernel.h>
++#include <asm/arch/ddr.h>
++
++struct dram_cfg_param ddr_ddrc_cfg[] = {
++	/** Initialize DDRC registers **/
++	{ 0x3d400304, 0x1 },
++	{ 0x3d400030, 0x1 },
++	{ 0x3d400000, 0xa3080020 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x3d400020, 0x223 },
++	{ 0x3d400024, 0x124f800 },
++	{ 0x3d400064, 0x4900a8 },
++	{ 0x3d400070, 0x1027f90 },
++	{ 0x3d400074, 0x790 },
++	{ 0x3d4000d0, 0xc0030495 },
++	{ 0x3d4000d4, 0x770000 },
++	{ 0x3d4000dc, 0xc40024 },
++#else
++	{ 0x3d400020, 0x1323 },
++	{ 0x3d400024, 0x1e84800 },
++	{ 0x3d400064, 0x7a017c },
++#ifdef CONFIG_IMX8M_DRAM_INLINE_ECC
++	{ 0x3d400070, 0x1027f54 },
++#else
++	{ 0x3d400070, 0x1027f10 },
++#endif
++	{ 0x3d400074, 0x7b0 },
++	{ 0x3d4000d0, 0xc00307a3 },
++	{ 0x3d4000d4, 0xc50000 },
++	{ 0x3d4000dc, 0xf4003f },
++#endif
++	{ 0x3d4000e0, 0x330000 },
++	{ 0x3d4000e8, 0x660048 },
++	{ 0x3d4000ec, 0x160048 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x3d400100, 0x1618141a },
++	{ 0x3d400104, 0x504a6 },
++	{ 0x3d40010c, 0x909000 },
++	{ 0x3d400110, 0xb04060b },
++	{ 0x3d400114, 0x2030909 },
++	{ 0x3d400118, 0x1010006 },
++	{ 0x3d40011c, 0x301 },
++	{ 0x3d400130, 0x20500 },
++	{ 0x3d400134, 0xb100002 },
++	{ 0x3d400138, 0xad },
++	{ 0x3d400144, 0x78003c },
++	{ 0x3d400180, 0x2580012 },
++	{ 0x3d400184, 0x1e0493e },
++	{ 0x3d400188, 0x0 },
++	{ 0x3d400190, 0x4938208 },
++	{ 0x3d400194, 0x80303 },
++	{ 0x3d4001b4, 0x1308 },
++#else
++	{ 0x3d400100, 0x2028222a },
++	{ 0x3d400104, 0x807bf },
++	{ 0x3d40010c, 0xe0e000 },
++	{ 0x3d400110, 0x12040a12 },
++	{ 0x3d400114, 0x2050f0f },
++	{ 0x3d400118, 0x1010009 },
++	{ 0x3d40011c, 0x501 },
++	{ 0x3d400130, 0x20800 },
++	{ 0x3d400134, 0xe100002 },
++	{ 0x3d400138, 0x184 },
++	{ 0x3d400144, 0xc80064 },
++	{ 0x3d400180, 0x3e8001e },
++	{ 0x3d400184, 0x3207a12 },
++	{ 0x3d400188, 0x0 },
++	{ 0x3d400190, 0x49f820e },
++	{ 0x3d400194, 0x80303 },
++	{ 0x3d4001b4, 0x1f0e },
++#endif
++	{ 0x3d4001a0, 0xe0400018 },
++	{ 0x3d4001a4, 0xdf00e4 },
++	{ 0x3d4001a8, 0x80000000 },
++	{ 0x3d4001b0, 0x11 },
++	{ 0x3d4001c0, 0x1 },
++	{ 0x3d4001c4, 0x1 },
++	{ 0x3d4000f4, 0xc99 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x3d400108, 0x60c1514 },
++	{ 0x3d400200, 0x16 },
++	{ 0x3d40020c, 0x0 },
++	{ 0x3d400210, 0x1f1f },
++	{ 0x3d400204, 0x80808 },
++	{ 0x3d400214, 0x7070707 },
++	{ 0x3d400218, 0x68070707 },
++	{ 0x3d40021c, 0xf08 },
++	{ 0x3d400250, 0x1f05 },
++	{ 0x3d400254, 0x1f },
++	{ 0x3d400264, 0x90003ff },
++	{ 0x3d40026c, 0x20003ff },
++	{ 0x3d400400, 0x111 },
++	{ 0x3d400408, 0x72ff },
++	{ 0x3d400494, 0x1000e00 },
++	{ 0x3d400498, 0x3ff0000 },
++	{ 0x3d40049c, 0x1000e00 },
++	{ 0x3d4004a0, 0x3ff0000 },
++	{ 0x3d402020, 0x21 },
++	{ 0x3d402024, 0x30d400 },
++	{ 0x3d402050, 0x20d000 },
++	{ 0x3d402064, 0xc001c },
++#else
++	{ 0x3d400108, 0x9121c1c },
++#ifdef CONFIG_IMX8M_DRAM_INLINE_ECC
++	{ 0x3d400200, 0x13 },
++	{ 0x3d40020c, 0x13131300 },
++	{ 0x3d400210, 0x1f1f },
++	{ 0x3d400204, 0x50505 },
++	{ 0x3d400214, 0x4040404 },
++	{ 0x3d400218, 0x68040404 },
++#else
++	{ 0x3d400200, 0x16 },
++	{ 0x3d40020c, 0x0 },
++	{ 0x3d400210, 0x1f1f },
++	{ 0x3d400204, 0x80808 },
++	{ 0x3d400214, 0x7070707 },
++	{ 0x3d400218, 0x68070707 },
++#endif
++	{ 0x3d40021c, 0xf08 },
++	{ 0x3d400250, 0x1705 },
++	{ 0x3d400254, 0x2c },
++	{ 0x3d40025c, 0x4000030 },
++	{ 0x3d400264, 0x900093e7 },
++	{ 0x3d40026c, 0x2005574 },
++	{ 0x3d400400, 0x111 },
++	{ 0x3d400404, 0x72ff },
++	{ 0x3d400408, 0x72ff },
++	{ 0x3d400494, 0x2100e07 },
++	{ 0x3d400498, 0x620096 },
++	{ 0x3d40049c, 0x1100e07 },
++	{ 0x3d4004a0, 0xc8012c },
++	{ 0x3d402020, 0x1021 },
++	{ 0x3d402024, 0x30d400 },
++	{ 0x3d402050, 0x20d000 },
++	{ 0x3d402064, 0xc0026 },
++#endif
++	{ 0x3d4020dc, 0x840000 },
++	{ 0x3d4020e0, 0x330000 },
++	{ 0x3d4020e8, 0x660048 },
++	{ 0x3d4020ec, 0x160048 },
++	{ 0x3d402100, 0xa040305 },
++	{ 0x3d402104, 0x30407 },
++	{ 0x3d402108, 0x203060b },
++	{ 0x3d40210c, 0x505000 },
++	{ 0x3d402110, 0x2040202 },
++	{ 0x3d402114, 0x2030202 },
++	{ 0x3d402118, 0x1010004 },
++	{ 0x3d40211c, 0x301 },
++	{ 0x3d402130, 0x20300 },
++	{ 0x3d402134, 0xa100002 },
++	{ 0x3d402138, 0x27 },
++	{ 0x3d402144, 0x14000a },
++	{ 0x3d402180, 0x640004 },
++	{ 0x3d402190, 0x3818200 },
++	{ 0x3d402194, 0x80303 },
++	{ 0x3d4021b4, 0x100 },
++	{ 0x3d4020f4, 0xc99 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x3d403020, 0x21 },
++	{ 0x3d403024, 0xc3500 },
++	{ 0x3d403050, 0x20d000 },
++	{ 0x3d403064, 0x30007 },
++#else
++	{ 0x3d403020, 0x1021 },
++	{ 0x3d403024, 0xc3500 },
++	{ 0x3d403050, 0x20d000 },
++	{ 0x3d403064, 0x3000a },
++#endif
++	{ 0x3d4030dc, 0x840000 },
++	{ 0x3d4030e0, 0x330000 },
++	{ 0x3d4030e8, 0x660048 },
++	{ 0x3d4030ec, 0x160048 },
++	{ 0x3d403100, 0xa010102 },
++	{ 0x3d403104, 0x30404 },
++	{ 0x3d403108, 0x203060b },
++	{ 0x3d40310c, 0x505000 },
++	{ 0x3d403110, 0x2040202 },
++	{ 0x3d403114, 0x2030202 },
++	{ 0x3d403118, 0x1010004 },
++	{ 0x3d40311c, 0x301 },
++	{ 0x3d403130, 0x20300 },
++	{ 0x3d403134, 0xa100002 },
++	{ 0x3d403138, 0xa },
++	{ 0x3d403144, 0x50003 },
++	{ 0x3d403180, 0x190004 },
++	{ 0x3d403190, 0x3818200 },
++	{ 0x3d403194, 0x80303 },
++	{ 0x3d4031b4, 0x100 },
++	{ 0x3d4030f4, 0xc99 },
++	{ 0x3d400028, 0x0 },
++};
++
++/* PHY Initialize Configuration */
++struct dram_cfg_param ddr_ddrphy_cfg[] = {
++	{ 0x100a0, 0x0 },
++	{ 0x100a1, 0x1 },
++	{ 0x100a2, 0x2 },
++	{ 0x100a3, 0x3 },
++	{ 0x100a4, 0x4 },
++	{ 0x100a5, 0x5 },
++	{ 0x100a6, 0x6 },
++	{ 0x100a7, 0x7 },
++	{ 0x110a0, 0x0 },
++	{ 0x110a1, 0x1 },
++	{ 0x110a2, 0x3 },
++	{ 0x110a3, 0x4 },
++	{ 0x110a4, 0x5 },
++	{ 0x110a5, 0x2 },
++	{ 0x110a6, 0x7 },
++	{ 0x110a7, 0x6 },
++	{ 0x120a0, 0x0 },
++	{ 0x120a1, 0x1 },
++	{ 0x120a2, 0x3 },
++	{ 0x120a3, 0x2 },
++	{ 0x120a4, 0x5 },
++	{ 0x120a5, 0x4 },
++	{ 0x120a6, 0x7 },
++	{ 0x120a7, 0x6 },
++	{ 0x130a0, 0x0 },
++	{ 0x130a1, 0x1 },
++	{ 0x130a2, 0x2 },
++	{ 0x130a3, 0x3 },
++	{ 0x130a4, 0x4 },
++	{ 0x130a5, 0x5 },
++	{ 0x130a6, 0x6 },
++	{ 0x130a7, 0x7 },
++	{ 0x1005f, 0x1ff },
++	{ 0x1015f, 0x1ff },
++	{ 0x1105f, 0x1ff },
++	{ 0x1115f, 0x1ff },
++	{ 0x1205f, 0x1ff },
++	{ 0x1215f, 0x1ff },
++	{ 0x1305f, 0x1ff },
++	{ 0x1315f, 0x1ff },
++	{ 0x11005f, 0x1ff },
++	{ 0x11015f, 0x1ff },
++	{ 0x11105f, 0x1ff },
++	{ 0x11115f, 0x1ff },
++	{ 0x11205f, 0x1ff },
++	{ 0x11215f, 0x1ff },
++	{ 0x11305f, 0x1ff },
++	{ 0x11315f, 0x1ff },
++	{ 0x21005f, 0x1ff },
++	{ 0x21015f, 0x1ff },
++	{ 0x21105f, 0x1ff },
++	{ 0x21115f, 0x1ff },
++	{ 0x21205f, 0x1ff },
++	{ 0x21215f, 0x1ff },
++	{ 0x21305f, 0x1ff },
++	{ 0x21315f, 0x1ff },
++	{ 0x55, 0x1ff },
++	{ 0x1055, 0x1ff },
++	{ 0x2055, 0x1ff },
++	{ 0x3055, 0x1ff },
++	{ 0x4055, 0x1ff },
++	{ 0x5055, 0x1ff },
++	{ 0x6055, 0x1ff },
++	{ 0x7055, 0x1ff },
++	{ 0x8055, 0x1ff },
++	{ 0x9055, 0x1ff },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x200c5, 0xa },
++#else
++	{ 0x200c5, 0x18 },
++#endif
++	{ 0x1200c5, 0x7 },
++	{ 0x2200c5, 0x7 },
++	{ 0x2002e, 0x2 },
++	{ 0x12002e, 0x2 },
++	{ 0x22002e, 0x2 },
++	{ 0x90204, 0x0 },
++	{ 0x190204, 0x0 },
++	{ 0x290204, 0x0 },
++	{ 0x20024, 0x1e3 },
++	{ 0x2003a, 0x2 },
++	{ 0x120024, 0x1e3 },
++	{ 0x2003a, 0x2 },
++	{ 0x220024, 0x1e3 },
++	{ 0x2003a, 0x2 },
++	{ 0x20056, 0x3 },
++	{ 0x120056, 0x3 },
++	{ 0x220056, 0x3 },
++	{ 0x1004d, 0xe00 },
++	{ 0x1014d, 0xe00 },
++	{ 0x1104d, 0xe00 },
++	{ 0x1114d, 0xe00 },
++	{ 0x1204d, 0xe00 },
++	{ 0x1214d, 0xe00 },
++	{ 0x1304d, 0xe00 },
++	{ 0x1314d, 0xe00 },
++	{ 0x11004d, 0xe00 },
++	{ 0x11014d, 0xe00 },
++	{ 0x11104d, 0xe00 },
++	{ 0x11114d, 0xe00 },
++	{ 0x11204d, 0xe00 },
++	{ 0x11214d, 0xe00 },
++	{ 0x11304d, 0xe00 },
++	{ 0x11314d, 0xe00 },
++	{ 0x21004d, 0xe00 },
++	{ 0x21014d, 0xe00 },
++	{ 0x21104d, 0xe00 },
++	{ 0x21114d, 0xe00 },
++	{ 0x21204d, 0xe00 },
++	{ 0x21214d, 0xe00 },
++	{ 0x21304d, 0xe00 },
++	{ 0x21314d, 0xe00 },
++	{ 0x10049, 0xeba },
++	{ 0x10149, 0xeba },
++	{ 0x11049, 0xeba },
++	{ 0x11149, 0xeba },
++	{ 0x12049, 0xeba },
++	{ 0x12149, 0xeba },
++	{ 0x13049, 0xeba },
++	{ 0x13149, 0xeba },
++	{ 0x110049, 0xeba },
++	{ 0x110149, 0xeba },
++	{ 0x111049, 0xeba },
++	{ 0x111149, 0xeba },
++	{ 0x112049, 0xeba },
++	{ 0x112149, 0xeba },
++	{ 0x113049, 0xeba },
++	{ 0x113149, 0xeba },
++	{ 0x210049, 0xeba },
++	{ 0x210149, 0xeba },
++	{ 0x211049, 0xeba },
++	{ 0x211149, 0xeba },
++	{ 0x212049, 0xeba },
++	{ 0x212149, 0xeba },
++	{ 0x213049, 0xeba },
++	{ 0x213149, 0xeba },
++	{ 0x43, 0x63 },
++	{ 0x1043, 0x63 },
++	{ 0x2043, 0x63 },
++	{ 0x3043, 0x63 },
++	{ 0x4043, 0x63 },
++	{ 0x5043, 0x63 },
++	{ 0x6043, 0x63 },
++	{ 0x7043, 0x63 },
++	{ 0x8043, 0x63 },
++	{ 0x9043, 0x63 },
++	{ 0x20018, 0x3 },
++	{ 0x20075, 0x4 },
++	{ 0x20050, 0x0 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x20008, 0x258 },
++#else
++	{ 0x20008, 0x3e8 },
++#endif
++	{ 0x120008, 0x64 },
++	{ 0x220008, 0x19 },
++	{ 0x20088, 0x9 },
++	{ 0x200b2, 0x104 },
++	{ 0x10043, 0x5a1 },
++	{ 0x10143, 0x5a1 },
++	{ 0x11043, 0x5a1 },
++	{ 0x11143, 0x5a1 },
++	{ 0x12043, 0x5a1 },
++	{ 0x12143, 0x5a1 },
++	{ 0x13043, 0x5a1 },
++	{ 0x13143, 0x5a1 },
++	{ 0x1200b2, 0x104 },
++	{ 0x110043, 0x5a1 },
++	{ 0x110143, 0x5a1 },
++	{ 0x111043, 0x5a1 },
++	{ 0x111143, 0x5a1 },
++	{ 0x112043, 0x5a1 },
++	{ 0x112143, 0x5a1 },
++	{ 0x113043, 0x5a1 },
++	{ 0x113143, 0x5a1 },
++	{ 0x2200b2, 0x104 },
++	{ 0x210043, 0x5a1 },
++	{ 0x210143, 0x5a1 },
++	{ 0x211043, 0x5a1 },
++	{ 0x211143, 0x5a1 },
++	{ 0x212043, 0x5a1 },
++	{ 0x212143, 0x5a1 },
++	{ 0x213043, 0x5a1 },
++	{ 0x213143, 0x5a1 },
++	{ 0x200fa, 0x1 },
++	{ 0x1200fa, 0x1 },
++	{ 0x2200fa, 0x1 },
++	{ 0x20019, 0x1 },
++	{ 0x120019, 0x1 },
++	{ 0x220019, 0x1 },
++	{ 0x200f0, 0x660 },
++	{ 0x200f1, 0x0 },
++	{ 0x200f2, 0x4444 },
++	{ 0x200f3, 0x8888 },
++	{ 0x200f4, 0x5665 },
++	{ 0x200f5, 0x0 },
++	{ 0x200f6, 0x0 },
++	{ 0x200f7, 0xf000 },
++	{ 0x20025, 0x0 },
++	{ 0x2002d, 0x0 },
++	{ 0x12002d, 0x0 },
++	{ 0x22002d, 0x0 },
++	{ 0x2007d, 0x212 },
++	{ 0x12007d, 0x212 },
++	{ 0x22007d, 0x212 },
++	{ 0x2007c, 0x61 },
++	{ 0x12007c, 0x61 },
++	{ 0x22007c, 0x61 },
++	{ 0x1004a, 0x500 },
++	{ 0x1104a, 0x500 },
++	{ 0x1204a, 0x500 },
++	{ 0x1304a, 0x500 },
++	{ 0x2002c, 0x0 },
++};
++
++/* ddr phy trained csr */
++struct dram_cfg_param ddr_ddrphy_trained_csr[] = {
++	{ 0x200b2, 0x0 },
++	{ 0x1200b2, 0x0 },
++	{ 0x2200b2, 0x0 },
++	{ 0x200cb, 0x0 },
++	{ 0x10043, 0x0 },
++	{ 0x110043, 0x0 },
++	{ 0x210043, 0x0 },
++	{ 0x10143, 0x0 },
++	{ 0x110143, 0x0 },
++	{ 0x210143, 0x0 },
++	{ 0x11043, 0x0 },
++	{ 0x111043, 0x0 },
++	{ 0x211043, 0x0 },
++	{ 0x11143, 0x0 },
++	{ 0x111143, 0x0 },
++	{ 0x211143, 0x0 },
++	{ 0x12043, 0x0 },
++	{ 0x112043, 0x0 },
++	{ 0x212043, 0x0 },
++	{ 0x12143, 0x0 },
++	{ 0x112143, 0x0 },
++	{ 0x212143, 0x0 },
++	{ 0x13043, 0x0 },
++	{ 0x113043, 0x0 },
++	{ 0x213043, 0x0 },
++	{ 0x13143, 0x0 },
++	{ 0x113143, 0x0 },
++	{ 0x213143, 0x0 },
++	{ 0x80, 0x0 },
++	{ 0x100080, 0x0 },
++	{ 0x200080, 0x0 },
++	{ 0x1080, 0x0 },
++	{ 0x101080, 0x0 },
++	{ 0x201080, 0x0 },
++	{ 0x2080, 0x0 },
++	{ 0x102080, 0x0 },
++	{ 0x202080, 0x0 },
++	{ 0x3080, 0x0 },
++	{ 0x103080, 0x0 },
++	{ 0x203080, 0x0 },
++	{ 0x4080, 0x0 },
++	{ 0x104080, 0x0 },
++	{ 0x204080, 0x0 },
++	{ 0x5080, 0x0 },
++	{ 0x105080, 0x0 },
++	{ 0x205080, 0x0 },
++	{ 0x6080, 0x0 },
++	{ 0x106080, 0x0 },
++	{ 0x206080, 0x0 },
++	{ 0x7080, 0x0 },
++	{ 0x107080, 0x0 },
++	{ 0x207080, 0x0 },
++	{ 0x8080, 0x0 },
++	{ 0x108080, 0x0 },
++	{ 0x208080, 0x0 },
++	{ 0x9080, 0x0 },
++	{ 0x109080, 0x0 },
++	{ 0x209080, 0x0 },
++	{ 0x10080, 0x0 },
++	{ 0x110080, 0x0 },
++	{ 0x210080, 0x0 },
++	{ 0x10180, 0x0 },
++	{ 0x110180, 0x0 },
++	{ 0x210180, 0x0 },
++	{ 0x11080, 0x0 },
++	{ 0x111080, 0x0 },
++	{ 0x211080, 0x0 },
++	{ 0x11180, 0x0 },
++	{ 0x111180, 0x0 },
++	{ 0x211180, 0x0 },
++	{ 0x12080, 0x0 },
++	{ 0x112080, 0x0 },
++	{ 0x212080, 0x0 },
++	{ 0x12180, 0x0 },
++	{ 0x112180, 0x0 },
++	{ 0x212180, 0x0 },
++	{ 0x13080, 0x0 },
++	{ 0x113080, 0x0 },
++	{ 0x213080, 0x0 },
++	{ 0x13180, 0x0 },
++	{ 0x113180, 0x0 },
++	{ 0x213180, 0x0 },
++	{ 0x10081, 0x0 },
++	{ 0x110081, 0x0 },
++	{ 0x210081, 0x0 },
++	{ 0x10181, 0x0 },
++	{ 0x110181, 0x0 },
++	{ 0x210181, 0x0 },
++	{ 0x11081, 0x0 },
++	{ 0x111081, 0x0 },
++	{ 0x211081, 0x0 },
++	{ 0x11181, 0x0 },
++	{ 0x111181, 0x0 },
++	{ 0x211181, 0x0 },
++	{ 0x12081, 0x0 },
++	{ 0x112081, 0x0 },
++	{ 0x212081, 0x0 },
++	{ 0x12181, 0x0 },
++	{ 0x112181, 0x0 },
++	{ 0x212181, 0x0 },
++	{ 0x13081, 0x0 },
++	{ 0x113081, 0x0 },
++	{ 0x213081, 0x0 },
++	{ 0x13181, 0x0 },
++	{ 0x113181, 0x0 },
++	{ 0x213181, 0x0 },
++	{ 0x100d0, 0x0 },
++	{ 0x1100d0, 0x0 },
++	{ 0x2100d0, 0x0 },
++	{ 0x101d0, 0x0 },
++	{ 0x1101d0, 0x0 },
++	{ 0x2101d0, 0x0 },
++	{ 0x110d0, 0x0 },
++	{ 0x1110d0, 0x0 },
++	{ 0x2110d0, 0x0 },
++	{ 0x111d0, 0x0 },
++	{ 0x1111d0, 0x0 },
++	{ 0x2111d0, 0x0 },
++	{ 0x120d0, 0x0 },
++	{ 0x1120d0, 0x0 },
++	{ 0x2120d0, 0x0 },
++	{ 0x121d0, 0x0 },
++	{ 0x1121d0, 0x0 },
++	{ 0x2121d0, 0x0 },
++	{ 0x130d0, 0x0 },
++	{ 0x1130d0, 0x0 },
++	{ 0x2130d0, 0x0 },
++	{ 0x131d0, 0x0 },
++	{ 0x1131d0, 0x0 },
++	{ 0x2131d0, 0x0 },
++	{ 0x100d1, 0x0 },
++	{ 0x1100d1, 0x0 },
++	{ 0x2100d1, 0x0 },
++	{ 0x101d1, 0x0 },
++	{ 0x1101d1, 0x0 },
++	{ 0x2101d1, 0x0 },
++	{ 0x110d1, 0x0 },
++	{ 0x1110d1, 0x0 },
++	{ 0x2110d1, 0x0 },
++	{ 0x111d1, 0x0 },
++	{ 0x1111d1, 0x0 },
++	{ 0x2111d1, 0x0 },
++	{ 0x120d1, 0x0 },
++	{ 0x1120d1, 0x0 },
++	{ 0x2120d1, 0x0 },
++	{ 0x121d1, 0x0 },
++	{ 0x1121d1, 0x0 },
++	{ 0x2121d1, 0x0 },
++	{ 0x130d1, 0x0 },
++	{ 0x1130d1, 0x0 },
++	{ 0x2130d1, 0x0 },
++	{ 0x131d1, 0x0 },
++	{ 0x1131d1, 0x0 },
++	{ 0x2131d1, 0x0 },
++	{ 0x10068, 0x0 },
++	{ 0x10168, 0x0 },
++	{ 0x10268, 0x0 },
++	{ 0x10368, 0x0 },
++	{ 0x10468, 0x0 },
++	{ 0x10568, 0x0 },
++	{ 0x10668, 0x0 },
++	{ 0x10768, 0x0 },
++	{ 0x10868, 0x0 },
++	{ 0x11068, 0x0 },
++	{ 0x11168, 0x0 },
++	{ 0x11268, 0x0 },
++	{ 0x11368, 0x0 },
++	{ 0x11468, 0x0 },
++	{ 0x11568, 0x0 },
++	{ 0x11668, 0x0 },
++	{ 0x11768, 0x0 },
++	{ 0x11868, 0x0 },
++	{ 0x12068, 0x0 },
++	{ 0x12168, 0x0 },
++	{ 0x12268, 0x0 },
++	{ 0x12368, 0x0 },
++	{ 0x12468, 0x0 },
++	{ 0x12568, 0x0 },
++	{ 0x12668, 0x0 },
++	{ 0x12768, 0x0 },
++	{ 0x12868, 0x0 },
++	{ 0x13068, 0x0 },
++	{ 0x13168, 0x0 },
++	{ 0x13268, 0x0 },
++	{ 0x13368, 0x0 },
++	{ 0x13468, 0x0 },
++	{ 0x13568, 0x0 },
++	{ 0x13668, 0x0 },
++	{ 0x13768, 0x0 },
++	{ 0x13868, 0x0 },
++	{ 0x10069, 0x0 },
++	{ 0x10169, 0x0 },
++	{ 0x10269, 0x0 },
++	{ 0x10369, 0x0 },
++	{ 0x10469, 0x0 },
++	{ 0x10569, 0x0 },
++	{ 0x10669, 0x0 },
++	{ 0x10769, 0x0 },
++	{ 0x10869, 0x0 },
++	{ 0x11069, 0x0 },
++	{ 0x11169, 0x0 },
++	{ 0x11269, 0x0 },
++	{ 0x11369, 0x0 },
++	{ 0x11469, 0x0 },
++	{ 0x11569, 0x0 },
++	{ 0x11669, 0x0 },
++	{ 0x11769, 0x0 },
++	{ 0x11869, 0x0 },
++	{ 0x12069, 0x0 },
++	{ 0x12169, 0x0 },
++	{ 0x12269, 0x0 },
++	{ 0x12369, 0x0 },
++	{ 0x12469, 0x0 },
++	{ 0x12569, 0x0 },
++	{ 0x12669, 0x0 },
++	{ 0x12769, 0x0 },
++	{ 0x12869, 0x0 },
++	{ 0x13069, 0x0 },
++	{ 0x13169, 0x0 },
++	{ 0x13269, 0x0 },
++	{ 0x13369, 0x0 },
++	{ 0x13469, 0x0 },
++	{ 0x13569, 0x0 },
++	{ 0x13669, 0x0 },
++	{ 0x13769, 0x0 },
++	{ 0x13869, 0x0 },
++	{ 0x1008c, 0x0 },
++	{ 0x11008c, 0x0 },
++	{ 0x21008c, 0x0 },
++	{ 0x1018c, 0x0 },
++	{ 0x11018c, 0x0 },
++	{ 0x21018c, 0x0 },
++	{ 0x1108c, 0x0 },
++	{ 0x11108c, 0x0 },
++	{ 0x21108c, 0x0 },
++	{ 0x1118c, 0x0 },
++	{ 0x11118c, 0x0 },
++	{ 0x21118c, 0x0 },
++	{ 0x1208c, 0x0 },
++	{ 0x11208c, 0x0 },
++	{ 0x21208c, 0x0 },
++	{ 0x1218c, 0x0 },
++	{ 0x11218c, 0x0 },
++	{ 0x21218c, 0x0 },
++	{ 0x1308c, 0x0 },
++	{ 0x11308c, 0x0 },
++	{ 0x21308c, 0x0 },
++	{ 0x1318c, 0x0 },
++	{ 0x11318c, 0x0 },
++	{ 0x21318c, 0x0 },
++	{ 0x1008d, 0x0 },
++	{ 0x11008d, 0x0 },
++	{ 0x21008d, 0x0 },
++	{ 0x1018d, 0x0 },
++	{ 0x11018d, 0x0 },
++	{ 0x21018d, 0x0 },
++	{ 0x1108d, 0x0 },
++	{ 0x11108d, 0x0 },
++	{ 0x21108d, 0x0 },
++	{ 0x1118d, 0x0 },
++	{ 0x11118d, 0x0 },
++	{ 0x21118d, 0x0 },
++	{ 0x1208d, 0x0 },
++	{ 0x11208d, 0x0 },
++	{ 0x21208d, 0x0 },
++	{ 0x1218d, 0x0 },
++	{ 0x11218d, 0x0 },
++	{ 0x21218d, 0x0 },
++	{ 0x1308d, 0x0 },
++	{ 0x11308d, 0x0 },
++	{ 0x21308d, 0x0 },
++	{ 0x1318d, 0x0 },
++	{ 0x11318d, 0x0 },
++	{ 0x21318d, 0x0 },
++	{ 0x100c0, 0x0 },
++	{ 0x1100c0, 0x0 },
++	{ 0x2100c0, 0x0 },
++	{ 0x101c0, 0x0 },
++	{ 0x1101c0, 0x0 },
++	{ 0x2101c0, 0x0 },
++	{ 0x102c0, 0x0 },
++	{ 0x1102c0, 0x0 },
++	{ 0x2102c0, 0x0 },
++	{ 0x103c0, 0x0 },
++	{ 0x1103c0, 0x0 },
++	{ 0x2103c0, 0x0 },
++	{ 0x104c0, 0x0 },
++	{ 0x1104c0, 0x0 },
++	{ 0x2104c0, 0x0 },
++	{ 0x105c0, 0x0 },
++	{ 0x1105c0, 0x0 },
++	{ 0x2105c0, 0x0 },
++	{ 0x106c0, 0x0 },
++	{ 0x1106c0, 0x0 },
++	{ 0x2106c0, 0x0 },
++	{ 0x107c0, 0x0 },
++	{ 0x1107c0, 0x0 },
++	{ 0x2107c0, 0x0 },
++	{ 0x108c0, 0x0 },
++	{ 0x1108c0, 0x0 },
++	{ 0x2108c0, 0x0 },
++	{ 0x110c0, 0x0 },
++	{ 0x1110c0, 0x0 },
++	{ 0x2110c0, 0x0 },
++	{ 0x111c0, 0x0 },
++	{ 0x1111c0, 0x0 },
++	{ 0x2111c0, 0x0 },
++	{ 0x112c0, 0x0 },
++	{ 0x1112c0, 0x0 },
++	{ 0x2112c0, 0x0 },
++	{ 0x113c0, 0x0 },
++	{ 0x1113c0, 0x0 },
++	{ 0x2113c0, 0x0 },
++	{ 0x114c0, 0x0 },
++	{ 0x1114c0, 0x0 },
++	{ 0x2114c0, 0x0 },
++	{ 0x115c0, 0x0 },
++	{ 0x1115c0, 0x0 },
++	{ 0x2115c0, 0x0 },
++	{ 0x116c0, 0x0 },
++	{ 0x1116c0, 0x0 },
++	{ 0x2116c0, 0x0 },
++	{ 0x117c0, 0x0 },
++	{ 0x1117c0, 0x0 },
++	{ 0x2117c0, 0x0 },
++	{ 0x118c0, 0x0 },
++	{ 0x1118c0, 0x0 },
++	{ 0x2118c0, 0x0 },
++	{ 0x120c0, 0x0 },
++	{ 0x1120c0, 0x0 },
++	{ 0x2120c0, 0x0 },
++	{ 0x121c0, 0x0 },
++	{ 0x1121c0, 0x0 },
++	{ 0x2121c0, 0x0 },
++	{ 0x122c0, 0x0 },
++	{ 0x1122c0, 0x0 },
++	{ 0x2122c0, 0x0 },
++	{ 0x123c0, 0x0 },
++	{ 0x1123c0, 0x0 },
++	{ 0x2123c0, 0x0 },
++	{ 0x124c0, 0x0 },
++	{ 0x1124c0, 0x0 },
++	{ 0x2124c0, 0x0 },
++	{ 0x125c0, 0x0 },
++	{ 0x1125c0, 0x0 },
++	{ 0x2125c0, 0x0 },
++	{ 0x126c0, 0x0 },
++	{ 0x1126c0, 0x0 },
++	{ 0x2126c0, 0x0 },
++	{ 0x127c0, 0x0 },
++	{ 0x1127c0, 0x0 },
++	{ 0x2127c0, 0x0 },
++	{ 0x128c0, 0x0 },
++	{ 0x1128c0, 0x0 },
++	{ 0x2128c0, 0x0 },
++	{ 0x130c0, 0x0 },
++	{ 0x1130c0, 0x0 },
++	{ 0x2130c0, 0x0 },
++	{ 0x131c0, 0x0 },
++	{ 0x1131c0, 0x0 },
++	{ 0x2131c0, 0x0 },
++	{ 0x132c0, 0x0 },
++	{ 0x1132c0, 0x0 },
++	{ 0x2132c0, 0x0 },
++	{ 0x133c0, 0x0 },
++	{ 0x1133c0, 0x0 },
++	{ 0x2133c0, 0x0 },
++	{ 0x134c0, 0x0 },
++	{ 0x1134c0, 0x0 },
++	{ 0x2134c0, 0x0 },
++	{ 0x135c0, 0x0 },
++	{ 0x1135c0, 0x0 },
++	{ 0x2135c0, 0x0 },
++	{ 0x136c0, 0x0 },
++	{ 0x1136c0, 0x0 },
++	{ 0x2136c0, 0x0 },
++	{ 0x137c0, 0x0 },
++	{ 0x1137c0, 0x0 },
++	{ 0x2137c0, 0x0 },
++	{ 0x138c0, 0x0 },
++	{ 0x1138c0, 0x0 },
++	{ 0x2138c0, 0x0 },
++	{ 0x100c1, 0x0 },
++	{ 0x1100c1, 0x0 },
++	{ 0x2100c1, 0x0 },
++	{ 0x101c1, 0x0 },
++	{ 0x1101c1, 0x0 },
++	{ 0x2101c1, 0x0 },
++	{ 0x102c1, 0x0 },
++	{ 0x1102c1, 0x0 },
++	{ 0x2102c1, 0x0 },
++	{ 0x103c1, 0x0 },
++	{ 0x1103c1, 0x0 },
++	{ 0x2103c1, 0x0 },
++	{ 0x104c1, 0x0 },
++	{ 0x1104c1, 0x0 },
++	{ 0x2104c1, 0x0 },
++	{ 0x105c1, 0x0 },
++	{ 0x1105c1, 0x0 },
++	{ 0x2105c1, 0x0 },
++	{ 0x106c1, 0x0 },
++	{ 0x1106c1, 0x0 },
++	{ 0x2106c1, 0x0 },
++	{ 0x107c1, 0x0 },
++	{ 0x1107c1, 0x0 },
++	{ 0x2107c1, 0x0 },
++	{ 0x108c1, 0x0 },
++	{ 0x1108c1, 0x0 },
++	{ 0x2108c1, 0x0 },
++	{ 0x110c1, 0x0 },
++	{ 0x1110c1, 0x0 },
++	{ 0x2110c1, 0x0 },
++	{ 0x111c1, 0x0 },
++	{ 0x1111c1, 0x0 },
++	{ 0x2111c1, 0x0 },
++	{ 0x112c1, 0x0 },
++	{ 0x1112c1, 0x0 },
++	{ 0x2112c1, 0x0 },
++	{ 0x113c1, 0x0 },
++	{ 0x1113c1, 0x0 },
++	{ 0x2113c1, 0x0 },
++	{ 0x114c1, 0x0 },
++	{ 0x1114c1, 0x0 },
++	{ 0x2114c1, 0x0 },
++	{ 0x115c1, 0x0 },
++	{ 0x1115c1, 0x0 },
++	{ 0x2115c1, 0x0 },
++	{ 0x116c1, 0x0 },
++	{ 0x1116c1, 0x0 },
++	{ 0x2116c1, 0x0 },
++	{ 0x117c1, 0x0 },
++	{ 0x1117c1, 0x0 },
++	{ 0x2117c1, 0x0 },
++	{ 0x118c1, 0x0 },
++	{ 0x1118c1, 0x0 },
++	{ 0x2118c1, 0x0 },
++	{ 0x120c1, 0x0 },
++	{ 0x1120c1, 0x0 },
++	{ 0x2120c1, 0x0 },
++	{ 0x121c1, 0x0 },
++	{ 0x1121c1, 0x0 },
++	{ 0x2121c1, 0x0 },
++	{ 0x122c1, 0x0 },
++	{ 0x1122c1, 0x0 },
++	{ 0x2122c1, 0x0 },
++	{ 0x123c1, 0x0 },
++	{ 0x1123c1, 0x0 },
++	{ 0x2123c1, 0x0 },
++	{ 0x124c1, 0x0 },
++	{ 0x1124c1, 0x0 },
++	{ 0x2124c1, 0x0 },
++	{ 0x125c1, 0x0 },
++	{ 0x1125c1, 0x0 },
++	{ 0x2125c1, 0x0 },
++	{ 0x126c1, 0x0 },
++	{ 0x1126c1, 0x0 },
++	{ 0x2126c1, 0x0 },
++	{ 0x127c1, 0x0 },
++	{ 0x1127c1, 0x0 },
++	{ 0x2127c1, 0x0 },
++	{ 0x128c1, 0x0 },
++	{ 0x1128c1, 0x0 },
++	{ 0x2128c1, 0x0 },
++	{ 0x130c1, 0x0 },
++	{ 0x1130c1, 0x0 },
++	{ 0x2130c1, 0x0 },
++	{ 0x131c1, 0x0 },
++	{ 0x1131c1, 0x0 },
++	{ 0x2131c1, 0x0 },
++	{ 0x132c1, 0x0 },
++	{ 0x1132c1, 0x0 },
++	{ 0x2132c1, 0x0 },
++	{ 0x133c1, 0x0 },
++	{ 0x1133c1, 0x0 },
++	{ 0x2133c1, 0x0 },
++	{ 0x134c1, 0x0 },
++	{ 0x1134c1, 0x0 },
++	{ 0x2134c1, 0x0 },
++	{ 0x135c1, 0x0 },
++	{ 0x1135c1, 0x0 },
++	{ 0x2135c1, 0x0 },
++	{ 0x136c1, 0x0 },
++	{ 0x1136c1, 0x0 },
++	{ 0x2136c1, 0x0 },
++	{ 0x137c1, 0x0 },
++	{ 0x1137c1, 0x0 },
++	{ 0x2137c1, 0x0 },
++	{ 0x138c1, 0x0 },
++	{ 0x1138c1, 0x0 },
++	{ 0x2138c1, 0x0 },
++	{ 0x10020, 0x0 },
++	{ 0x110020, 0x0 },
++	{ 0x210020, 0x0 },
++	{ 0x11020, 0x0 },
++	{ 0x111020, 0x0 },
++	{ 0x211020, 0x0 },
++	{ 0x12020, 0x0 },
++	{ 0x112020, 0x0 },
++	{ 0x212020, 0x0 },
++	{ 0x13020, 0x0 },
++	{ 0x113020, 0x0 },
++	{ 0x213020, 0x0 },
++	{ 0x20072, 0x0 },
++	{ 0x20073, 0x0 },
++	{ 0x20074, 0x0 },
++	{ 0x100aa, 0x0 },
++	{ 0x110aa, 0x0 },
++	{ 0x120aa, 0x0 },
++	{ 0x130aa, 0x0 },
++	{ 0x20010, 0x0 },
++	{ 0x120010, 0x0 },
++	{ 0x220010, 0x0 },
++	{ 0x20011, 0x0 },
++	{ 0x120011, 0x0 },
++	{ 0x220011, 0x0 },
++	{ 0x100ae, 0x0 },
++	{ 0x1100ae, 0x0 },
++	{ 0x2100ae, 0x0 },
++	{ 0x100af, 0x0 },
++	{ 0x1100af, 0x0 },
++	{ 0x2100af, 0x0 },
++	{ 0x110ae, 0x0 },
++	{ 0x1110ae, 0x0 },
++	{ 0x2110ae, 0x0 },
++	{ 0x110af, 0x0 },
++	{ 0x1110af, 0x0 },
++	{ 0x2110af, 0x0 },
++	{ 0x120ae, 0x0 },
++	{ 0x1120ae, 0x0 },
++	{ 0x2120ae, 0x0 },
++	{ 0x120af, 0x0 },
++	{ 0x1120af, 0x0 },
++	{ 0x2120af, 0x0 },
++	{ 0x130ae, 0x0 },
++	{ 0x1130ae, 0x0 },
++	{ 0x2130ae, 0x0 },
++	{ 0x130af, 0x0 },
++	{ 0x1130af, 0x0 },
++	{ 0x2130af, 0x0 },
++	{ 0x20020, 0x0 },
++	{ 0x120020, 0x0 },
++	{ 0x220020, 0x0 },
++	{ 0x100a0, 0x0 },
++	{ 0x100a1, 0x0 },
++	{ 0x100a2, 0x0 },
++	{ 0x100a3, 0x0 },
++	{ 0x100a4, 0x0 },
++	{ 0x100a5, 0x0 },
++	{ 0x100a6, 0x0 },
++	{ 0x100a7, 0x0 },
++	{ 0x110a0, 0x0 },
++	{ 0x110a1, 0x0 },
++	{ 0x110a2, 0x0 },
++	{ 0x110a3, 0x0 },
++	{ 0x110a4, 0x0 },
++	{ 0x110a5, 0x0 },
++	{ 0x110a6, 0x0 },
++	{ 0x110a7, 0x0 },
++	{ 0x120a0, 0x0 },
++	{ 0x120a1, 0x0 },
++	{ 0x120a2, 0x0 },
++	{ 0x120a3, 0x0 },
++	{ 0x120a4, 0x0 },
++	{ 0x120a5, 0x0 },
++	{ 0x120a6, 0x0 },
++	{ 0x120a7, 0x0 },
++	{ 0x130a0, 0x0 },
++	{ 0x130a1, 0x0 },
++	{ 0x130a2, 0x0 },
++	{ 0x130a3, 0x0 },
++	{ 0x130a4, 0x0 },
++	{ 0x130a5, 0x0 },
++	{ 0x130a6, 0x0 },
++	{ 0x130a7, 0x0 },
++	{ 0x2007c, 0x0 },
++	{ 0x12007c, 0x0 },
++	{ 0x22007c, 0x0 },
++	{ 0x2007d, 0x0 },
++	{ 0x12007d, 0x0 },
++	{ 0x22007d, 0x0 },
++	{ 0x400fd, 0x0 },
++	{ 0x400c0, 0x0 },
++	{ 0x90201, 0x0 },
++	{ 0x190201, 0x0 },
++	{ 0x290201, 0x0 },
++	{ 0x90202, 0x0 },
++	{ 0x190202, 0x0 },
++	{ 0x290202, 0x0 },
++	{ 0x90203, 0x0 },
++	{ 0x190203, 0x0 },
++	{ 0x290203, 0x0 },
++	{ 0x90204, 0x0 },
++	{ 0x190204, 0x0 },
++	{ 0x290204, 0x0 },
++	{ 0x90205, 0x0 },
++	{ 0x190205, 0x0 },
++	{ 0x290205, 0x0 },
++	{ 0x90206, 0x0 },
++	{ 0x190206, 0x0 },
++	{ 0x290206, 0x0 },
++	{ 0x90207, 0x0 },
++	{ 0x190207, 0x0 },
++	{ 0x290207, 0x0 },
++	{ 0x90208, 0x0 },
++	{ 0x190208, 0x0 },
++	{ 0x290208, 0x0 },
++	{ 0x10062, 0x0 },
++	{ 0x10162, 0x0 },
++	{ 0x10262, 0x0 },
++	{ 0x10362, 0x0 },
++	{ 0x10462, 0x0 },
++	{ 0x10562, 0x0 },
++	{ 0x10662, 0x0 },
++	{ 0x10762, 0x0 },
++	{ 0x10862, 0x0 },
++	{ 0x11062, 0x0 },
++	{ 0x11162, 0x0 },
++	{ 0x11262, 0x0 },
++	{ 0x11362, 0x0 },
++	{ 0x11462, 0x0 },
++	{ 0x11562, 0x0 },
++	{ 0x11662, 0x0 },
++	{ 0x11762, 0x0 },
++	{ 0x11862, 0x0 },
++	{ 0x12062, 0x0 },
++	{ 0x12162, 0x0 },
++	{ 0x12262, 0x0 },
++	{ 0x12362, 0x0 },
++	{ 0x12462, 0x0 },
++	{ 0x12562, 0x0 },
++	{ 0x12662, 0x0 },
++	{ 0x12762, 0x0 },
++	{ 0x12862, 0x0 },
++	{ 0x13062, 0x0 },
++	{ 0x13162, 0x0 },
++	{ 0x13262, 0x0 },
++	{ 0x13362, 0x0 },
++	{ 0x13462, 0x0 },
++	{ 0x13562, 0x0 },
++	{ 0x13662, 0x0 },
++	{ 0x13762, 0x0 },
++	{ 0x13862, 0x0 },
++	{ 0x20077, 0x0 },
++	{ 0x10001, 0x0 },
++	{ 0x11001, 0x0 },
++	{ 0x12001, 0x0 },
++	{ 0x13001, 0x0 },
++	{ 0x10040, 0x0 },
++	{ 0x10140, 0x0 },
++	{ 0x10240, 0x0 },
++	{ 0x10340, 0x0 },
++	{ 0x10440, 0x0 },
++	{ 0x10540, 0x0 },
++	{ 0x10640, 0x0 },
++	{ 0x10740, 0x0 },
++	{ 0x10840, 0x0 },
++	{ 0x10030, 0x0 },
++	{ 0x10130, 0x0 },
++	{ 0x10230, 0x0 },
++	{ 0x10330, 0x0 },
++	{ 0x10430, 0x0 },
++	{ 0x10530, 0x0 },
++	{ 0x10630, 0x0 },
++	{ 0x10730, 0x0 },
++	{ 0x10830, 0x0 },
++	{ 0x11040, 0x0 },
++	{ 0x11140, 0x0 },
++	{ 0x11240, 0x0 },
++	{ 0x11340, 0x0 },
++	{ 0x11440, 0x0 },
++	{ 0x11540, 0x0 },
++	{ 0x11640, 0x0 },
++	{ 0x11740, 0x0 },
++	{ 0x11840, 0x0 },
++	{ 0x11030, 0x0 },
++	{ 0x11130, 0x0 },
++	{ 0x11230, 0x0 },
++	{ 0x11330, 0x0 },
++	{ 0x11430, 0x0 },
++	{ 0x11530, 0x0 },
++	{ 0x11630, 0x0 },
++	{ 0x11730, 0x0 },
++	{ 0x11830, 0x0 },
++	{ 0x12040, 0x0 },
++	{ 0x12140, 0x0 },
++	{ 0x12240, 0x0 },
++	{ 0x12340, 0x0 },
++	{ 0x12440, 0x0 },
++	{ 0x12540, 0x0 },
++	{ 0x12640, 0x0 },
++	{ 0x12740, 0x0 },
++	{ 0x12840, 0x0 },
++	{ 0x12030, 0x0 },
++	{ 0x12130, 0x0 },
++	{ 0x12230, 0x0 },
++	{ 0x12330, 0x0 },
++	{ 0x12430, 0x0 },
++	{ 0x12530, 0x0 },
++	{ 0x12630, 0x0 },
++	{ 0x12730, 0x0 },
++	{ 0x12830, 0x0 },
++	{ 0x13040, 0x0 },
++	{ 0x13140, 0x0 },
++	{ 0x13240, 0x0 },
++	{ 0x13340, 0x0 },
++	{ 0x13440, 0x0 },
++	{ 0x13540, 0x0 },
++	{ 0x13640, 0x0 },
++	{ 0x13740, 0x0 },
++	{ 0x13840, 0x0 },
++	{ 0x13030, 0x0 },
++	{ 0x13130, 0x0 },
++	{ 0x13230, 0x0 },
++	{ 0x13330, 0x0 },
++	{ 0x13430, 0x0 },
++	{ 0x13530, 0x0 },
++	{ 0x13630, 0x0 },
++	{ 0x13730, 0x0 },
++	{ 0x13830, 0x0 },
++};
++
++/* P0 message block paremeter for training firmware */
++struct dram_cfg_param ddr_fsp0_cfg[] = {
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0xd0000, 0x0 },
++	{ 0x54003, 0x960 },
++	{ 0x54004, 0x2 },
++	{ 0x54005, 0x2228 },
++	{ 0x54006, 0x14 },
++	{ 0x54008, 0x131f },
++	{ 0x54009, 0xc8 },
++	{ 0x5400b, 0x2 },
++	{ 0x5400f, 0x100 },
++	{ 0x54012, 0x310 },
++	{ 0x54019, 0x24c4 },
++	{ 0x5401a, 0x33 },
++	{ 0x5401b, 0x4866 },
++	{ 0x5401c, 0x4800 },
++	{ 0x5401e, 0x16 },
++	{ 0x5401f, 0x24c4 },
++	{ 0x54020, 0x33 },
++	{ 0x54021, 0x4866 },
++	{ 0x54022, 0x4800 },
++	{ 0x54024, 0x16 },
++	{ 0x5402b, 0x1000 },
++	{ 0x5402c, 0x3 },
++	{ 0x54032, 0xc400 },
++	{ 0x54033, 0x3324 },
++	{ 0x54034, 0x6600 },
++	{ 0x54035, 0x48 },
++	{ 0x54036, 0x48 },
++	{ 0x54037, 0x1600 },
++	{ 0x54038, 0xc400 },
++	{ 0x54039, 0x3324 },
++#else
++	{ 0xd0000, 0x0 },
++	{ 0x54003, 0xfa0 },
++	{ 0x54004, 0x2 },
++	{ 0x54005, 0x2228 },
++	{ 0x54006, 0x14 },
++	{ 0x54008, 0x131f },
++	{ 0x54009, 0xc8 },
++	{ 0x5400b, 0x2 },
++	{ 0x5400f, 0x100 },
++	{ 0x54012, 0x310 },
++	{ 0x54019, 0x3ff4 },
++	{ 0x5401a, 0x33 },
++	{ 0x5401b, 0x4866 },
++	{ 0x5401c, 0x4800 },
++	{ 0x5401e, 0x16 },
++	{ 0x5401f, 0x3ff4 },
++	{ 0x54020, 0x33 },
++	{ 0x54021, 0x4866 },
++	{ 0x54022, 0x4800 },
++	{ 0x54024, 0x16 },
++	{ 0x5402b, 0x1000 },
++	{ 0x5402c, 0x3 },
++	{ 0x54032, 0xf400 },
++	{ 0x54033, 0x333f },
++	{ 0x54034, 0x6600 },
++	{ 0x54035, 0x48 },
++	{ 0x54036, 0x48 },
++	{ 0x54037, 0x1600 },
++	{ 0x54038, 0xf400 },
++	{ 0x54039, 0x333f },
++#endif
++	{ 0x5403a, 0x6600 },
++	{ 0x5403b, 0x48 },
++	{ 0x5403c, 0x48 },
++	{ 0x5403d, 0x1600 },
++	{ 0xd0000, 0x1 },
++};
++
++/* P1 message block paremeter for training firmware */
++struct dram_cfg_param ddr_fsp1_cfg[] = {
++	{ 0xd0000, 0x0 },
++	{ 0x54002, 0x101 },
++	{ 0x54003, 0x190 },
++	{ 0x54004, 0x2 },
++	{ 0x54005, 0x2228 },
++	{ 0x54006, 0x14 },
++	{ 0x54008, 0x121f },
++	{ 0x54009, 0xc8 },
++	{ 0x5400b, 0x2 },
++	{ 0x5400f, 0x100 },
++	{ 0x54012, 0x310 },
++	{ 0x54019, 0x84 },
++	{ 0x5401a, 0x33 },
++	{ 0x5401b, 0x4866 },
++	{ 0x5401c, 0x4800 },
++	{ 0x5401e, 0x16 },
++	{ 0x5401f, 0x84 },
++	{ 0x54020, 0x33 },
++	{ 0x54021, 0x4866 },
++	{ 0x54022, 0x4800 },
++	{ 0x54024, 0x16 },
++	{ 0x5402b, 0x1000 },
++	{ 0x5402c, 0x3 },
++	{ 0x54032, 0x8400 },
++	{ 0x54033, 0x3300 },
++	{ 0x54034, 0x6600 },
++	{ 0x54035, 0x48 },
++	{ 0x54036, 0x48 },
++	{ 0x54037, 0x1600 },
++	{ 0x54038, 0x8400 },
++	{ 0x54039, 0x3300 },
++	{ 0x5403a, 0x6600 },
++	{ 0x5403b, 0x48 },
++	{ 0x5403c, 0x48 },
++	{ 0x5403d, 0x1600 },
++	{ 0xd0000, 0x1 },
++};
++
++/* P2 message block paremeter for training firmware */
++struct dram_cfg_param ddr_fsp2_cfg[] = {
++	{ 0xd0000, 0x0 },
++	{ 0x54002, 0x102 },
++	{ 0x54003, 0x64 },
++	{ 0x54004, 0x2 },
++	{ 0x54005, 0x2228 },
++	{ 0x54006, 0x14 },
++	{ 0x54008, 0x121f },
++	{ 0x54009, 0xc8 },
++	{ 0x5400b, 0x2 },
++	{ 0x5400f, 0x100 },
++	{ 0x54012, 0x310 },
++	{ 0x54019, 0x84 },
++	{ 0x5401a, 0x33 },
++	{ 0x5401b, 0x4866 },
++	{ 0x5401c, 0x4800 },
++	{ 0x5401e, 0x16 },
++	{ 0x5401f, 0x84 },
++	{ 0x54020, 0x33 },
++	{ 0x54021, 0x4866 },
++	{ 0x54022, 0x4800 },
++	{ 0x54024, 0x16 },
++	{ 0x5402b, 0x1000 },
++	{ 0x5402c, 0x3 },
++	{ 0x54032, 0x8400 },
++	{ 0x54033, 0x3300 },
++	{ 0x54034, 0x6600 },
++	{ 0x54035, 0x48 },
++	{ 0x54036, 0x48 },
++	{ 0x54037, 0x1600 },
++	{ 0x54038, 0x8400 },
++	{ 0x54039, 0x3300 },
++	{ 0x5403a, 0x6600 },
++	{ 0x5403b, 0x48 },
++	{ 0x5403c, 0x48 },
++	{ 0x5403d, 0x1600 },
++	{ 0xd0000, 0x1 },
++};
++
++/* P0 2D message block paremeter for training firmware */
++struct dram_cfg_param ddr_fsp0_2d_cfg[] = {
++	{ 0xd0000, 0x0 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x54003, 0x960 },
++	{ 0x54004, 0x2 },
++	{ 0x54005, 0x2228 },
++	{ 0x54006, 0x14 },
++	{ 0x54008, 0x61 },
++	{ 0x54009, 0xc8 },
++	{ 0x5400b, 0x2 },
++	{ 0x5400f, 0x100 },
++	{ 0x54010, 0x1f7f },
++	{ 0x54012, 0x310 },
++	{ 0x54019, 0x24c4 },
++	{ 0x5401a, 0x33 },
++	{ 0x5401b, 0x4866 },
++	{ 0x5401c, 0x4800 },
++	{ 0x5401e, 0x16 },
++	{ 0x5401f, 0x24c4 },
++	{ 0x54020, 0x33 },
++	{ 0x54021, 0x4866 },
++	{ 0x54022, 0x4800 },
++	{ 0x54024, 0x16 },
++	{ 0x5402b, 0x1000 },
++	{ 0x5402c, 0x3 },
++	{ 0x54032, 0xc400 },
++	{ 0x54033, 0x3324 },
++	{ 0x54034, 0x6600 },
++	{ 0x54035, 0x48 },
++	{ 0x54036, 0x48 },
++	{ 0x54037, 0x1600 },
++	{ 0x54038, 0xc400 },
++	{ 0x54039, 0x3324 },
++#else
++	{ 0x54003, 0xfa0 },
++	{ 0x54004, 0x2 },
++	{ 0x54005, 0x2228 },
++	{ 0x54006, 0x14 },
++	{ 0x54008, 0x61 },
++	{ 0x54009, 0xc8 },
++	{ 0x5400b, 0x2 },
++	{ 0x5400f, 0x100 },
++	{ 0x54010, 0x1f7f },
++	{ 0x54012, 0x310 },
++	{ 0x54019, 0x3ff4 },
++	{ 0x5401a, 0x33 },
++	{ 0x5401b, 0x4866 },
++	{ 0x5401c, 0x4800 },
++	{ 0x5401e, 0x16 },
++	{ 0x5401f, 0x3ff4 },
++	{ 0x54020, 0x33 },
++	{ 0x54021, 0x4866 },
++	{ 0x54022, 0x4800 },
++	{ 0x54024, 0x16 },
++	{ 0x5402b, 0x1000 },
++	{ 0x5402c, 0x3 },
++	{ 0x54032, 0xf400 },
++	{ 0x54033, 0x333f },
++	{ 0x54034, 0x6600 },
++	{ 0x54035, 0x48 },
++	{ 0x54036, 0x48 },
++	{ 0x54037, 0x1600 },
++	{ 0x54038, 0xf400 },
++	{ 0x54039, 0x333f },
++#endif
++	{ 0x5403a, 0x6600 },
++	{ 0x5403b, 0x48 },
++	{ 0x5403c, 0x48 },
++	{ 0x5403d, 0x1600 },
++	{ 0xd0000, 0x1 },
++};
++
++/* DRAM PHY init engine image */
++struct dram_cfg_param ddr_phy_pie[] = {
++	{ 0xd0000, 0x0 },
++	{ 0x90000, 0x10 },
++	{ 0x90001, 0x400 },
++	{ 0x90002, 0x10e },
++	{ 0x90003, 0x0 },
++	{ 0x90004, 0x0 },
++	{ 0x90005, 0x8 },
++	{ 0x90029, 0xb },
++	{ 0x9002a, 0x480 },
++	{ 0x9002b, 0x109 },
++	{ 0x9002c, 0x8 },
++	{ 0x9002d, 0x448 },
++	{ 0x9002e, 0x139 },
++	{ 0x9002f, 0x8 },
++	{ 0x90030, 0x478 },
++	{ 0x90031, 0x109 },
++	{ 0x90032, 0x0 },
++	{ 0x90033, 0xe8 },
++	{ 0x90034, 0x109 },
++	{ 0x90035, 0x2 },
++	{ 0x90036, 0x10 },
++	{ 0x90037, 0x139 },
++	{ 0x90038, 0xb },
++	{ 0x90039, 0x7c0 },
++	{ 0x9003a, 0x139 },
++	{ 0x9003b, 0x44 },
++	{ 0x9003c, 0x633 },
++	{ 0x9003d, 0x159 },
++	{ 0x9003e, 0x14f },
++	{ 0x9003f, 0x630 },
++	{ 0x90040, 0x159 },
++	{ 0x90041, 0x47 },
++	{ 0x90042, 0x633 },
++	{ 0x90043, 0x149 },
++	{ 0x90044, 0x4f },
++	{ 0x90045, 0x633 },
++	{ 0x90046, 0x179 },
++	{ 0x90047, 0x8 },
++	{ 0x90048, 0xe0 },
++	{ 0x90049, 0x109 },
++	{ 0x9004a, 0x0 },
++	{ 0x9004b, 0x7c8 },
++	{ 0x9004c, 0x109 },
++	{ 0x9004d, 0x0 },
++	{ 0x9004e, 0x1 },
++	{ 0x9004f, 0x8 },
++	{ 0x90050, 0x0 },
++	{ 0x90051, 0x45a },
++	{ 0x90052, 0x9 },
++	{ 0x90053, 0x0 },
++	{ 0x90054, 0x448 },
++	{ 0x90055, 0x109 },
++	{ 0x90056, 0x40 },
++	{ 0x90057, 0x633 },
++	{ 0x90058, 0x179 },
++	{ 0x90059, 0x1 },
++	{ 0x9005a, 0x618 },
++	{ 0x9005b, 0x109 },
++	{ 0x9005c, 0x40c0 },
++	{ 0x9005d, 0x633 },
++	{ 0x9005e, 0x149 },
++	{ 0x9005f, 0x8 },
++	{ 0x90060, 0x4 },
++	{ 0x90061, 0x48 },
++	{ 0x90062, 0x4040 },
++	{ 0x90063, 0x633 },
++	{ 0x90064, 0x149 },
++	{ 0x90065, 0x0 },
++	{ 0x90066, 0x4 },
++	{ 0x90067, 0x48 },
++	{ 0x90068, 0x40 },
++	{ 0x90069, 0x633 },
++	{ 0x9006a, 0x149 },
++	{ 0x9006b, 0x10 },
++	{ 0x9006c, 0x4 },
++	{ 0x9006d, 0x18 },
++	{ 0x9006e, 0x0 },
++	{ 0x9006f, 0x4 },
++	{ 0x90070, 0x78 },
++	{ 0x90071, 0x549 },
++	{ 0x90072, 0x633 },
++	{ 0x90073, 0x159 },
++	{ 0x90074, 0xd49 },
++	{ 0x90075, 0x633 },
++	{ 0x90076, 0x159 },
++	{ 0x90077, 0x94a },
++	{ 0x90078, 0x633 },
++	{ 0x90079, 0x159 },
++	{ 0x9007a, 0x441 },
++	{ 0x9007b, 0x633 },
++	{ 0x9007c, 0x149 },
++	{ 0x9007d, 0x42 },
++	{ 0x9007e, 0x633 },
++	{ 0x9007f, 0x149 },
++	{ 0x90080, 0x1 },
++	{ 0x90081, 0x633 },
++	{ 0x90082, 0x149 },
++	{ 0x90083, 0x0 },
++	{ 0x90084, 0xe0 },
++	{ 0x90085, 0x109 },
++	{ 0x90086, 0xa },
++	{ 0x90087, 0x10 },
++	{ 0x90088, 0x109 },
++	{ 0x90089, 0x9 },
++	{ 0x9008a, 0x3c0 },
++	{ 0x9008b, 0x149 },
++	{ 0x9008c, 0x9 },
++	{ 0x9008d, 0x3c0 },
++	{ 0x9008e, 0x159 },
++	{ 0x9008f, 0x18 },
++	{ 0x90090, 0x10 },
++	{ 0x90091, 0x109 },
++	{ 0x90092, 0x0 },
++	{ 0x90093, 0x3c0 },
++	{ 0x90094, 0x109 },
++	{ 0x90095, 0x18 },
++	{ 0x90096, 0x4 },
++	{ 0x90097, 0x48 },
++	{ 0x90098, 0x18 },
++	{ 0x90099, 0x4 },
++	{ 0x9009a, 0x58 },
++	{ 0x9009b, 0xb },
++	{ 0x9009c, 0x10 },
++	{ 0x9009d, 0x109 },
++	{ 0x9009e, 0x1 },
++	{ 0x9009f, 0x10 },
++	{ 0x900a0, 0x109 },
++	{ 0x900a1, 0x5 },
++	{ 0x900a2, 0x7c0 },
++	{ 0x900a3, 0x109 },
++	{ 0x40000, 0x811 },
++	{ 0x40020, 0x880 },
++	{ 0x40040, 0x0 },
++	{ 0x40060, 0x0 },
++	{ 0x40001, 0x4008 },
++	{ 0x40021, 0x83 },
++	{ 0x40041, 0x4f },
++	{ 0x40061, 0x0 },
++	{ 0x40002, 0x4040 },
++	{ 0x40022, 0x83 },
++	{ 0x40042, 0x51 },
++	{ 0x40062, 0x0 },
++	{ 0x40003, 0x811 },
++	{ 0x40023, 0x880 },
++	{ 0x40043, 0x0 },
++	{ 0x40063, 0x0 },
++	{ 0x40004, 0x720 },
++	{ 0x40024, 0xf },
++	{ 0x40044, 0x1740 },
++	{ 0x40064, 0x0 },
++	{ 0x40005, 0x16 },
++	{ 0x40025, 0x83 },
++	{ 0x40045, 0x4b },
++	{ 0x40065, 0x0 },
++	{ 0x40006, 0x716 },
++	{ 0x40026, 0xf },
++	{ 0x40046, 0x2001 },
++	{ 0x40066, 0x0 },
++	{ 0x40007, 0x716 },
++	{ 0x40027, 0xf },
++	{ 0x40047, 0x2800 },
++	{ 0x40067, 0x0 },
++	{ 0x40008, 0x716 },
++	{ 0x40028, 0xf },
++	{ 0x40048, 0xf00 },
++	{ 0x40068, 0x0 },
++	{ 0x40009, 0x720 },
++	{ 0x40029, 0xf },
++	{ 0x40049, 0x1400 },
++	{ 0x40069, 0x0 },
++	{ 0x4000a, 0xe08 },
++	{ 0x4002a, 0xc15 },
++	{ 0x4004a, 0x0 },
++	{ 0x4006a, 0x0 },
++	{ 0x4000b, 0x625 },
++	{ 0x4002b, 0x15 },
++	{ 0x4004b, 0x0 },
++	{ 0x4006b, 0x0 },
++	{ 0x4000c, 0x4028 },
++	{ 0x4002c, 0x80 },
++	{ 0x4004c, 0x0 },
++	{ 0x4006c, 0x0 },
++	{ 0x4000d, 0xe08 },
++	{ 0x4002d, 0xc1a },
++	{ 0x4004d, 0x0 },
++	{ 0x4006d, 0x0 },
++	{ 0x4000e, 0x625 },
++	{ 0x4002e, 0x1a },
++	{ 0x4004e, 0x0 },
++	{ 0x4006e, 0x0 },
++	{ 0x4000f, 0x4040 },
++	{ 0x4002f, 0x80 },
++	{ 0x4004f, 0x0 },
++	{ 0x4006f, 0x0 },
++	{ 0x40010, 0x2604 },
++	{ 0x40030, 0x15 },
++	{ 0x40050, 0x0 },
++	{ 0x40070, 0x0 },
++	{ 0x40011, 0x708 },
++	{ 0x40031, 0x5 },
++	{ 0x40051, 0x0 },
++	{ 0x40071, 0x2002 },
++	{ 0x40012, 0x8 },
++	{ 0x40032, 0x80 },
++	{ 0x40052, 0x0 },
++	{ 0x40072, 0x0 },
++	{ 0x40013, 0x2604 },
++	{ 0x40033, 0x1a },
++	{ 0x40053, 0x0 },
++	{ 0x40073, 0x0 },
++	{ 0x40014, 0x708 },
++	{ 0x40034, 0xa },
++	{ 0x40054, 0x0 },
++	{ 0x40074, 0x2002 },
++	{ 0x40015, 0x4040 },
++	{ 0x40035, 0x80 },
++	{ 0x40055, 0x0 },
++	{ 0x40075, 0x0 },
++	{ 0x40016, 0x60a },
++	{ 0x40036, 0x15 },
++	{ 0x40056, 0x1200 },
++	{ 0x40076, 0x0 },
++	{ 0x40017, 0x61a },
++	{ 0x40037, 0x15 },
++	{ 0x40057, 0x1300 },
++	{ 0x40077, 0x0 },
++	{ 0x40018, 0x60a },
++	{ 0x40038, 0x1a },
++	{ 0x40058, 0x1200 },
++	{ 0x40078, 0x0 },
++	{ 0x40019, 0x642 },
++	{ 0x40039, 0x1a },
++	{ 0x40059, 0x1300 },
++	{ 0x40079, 0x0 },
++	{ 0x4001a, 0x4808 },
++	{ 0x4003a, 0x880 },
++	{ 0x4005a, 0x0 },
++	{ 0x4007a, 0x0 },
++	{ 0x900a4, 0x0 },
++	{ 0x900a5, 0x790 },
++	{ 0x900a6, 0x11a },
++	{ 0x900a7, 0x8 },
++	{ 0x900a8, 0x7aa },
++	{ 0x900a9, 0x2a },
++	{ 0x900aa, 0x10 },
++	{ 0x900ab, 0x7b2 },
++	{ 0x900ac, 0x2a },
++	{ 0x900ad, 0x0 },
++	{ 0x900ae, 0x7c8 },
++	{ 0x900af, 0x109 },
++	{ 0x900b0, 0x10 },
++	{ 0x900b1, 0x10 },
++	{ 0x900b2, 0x109 },
++	{ 0x900b3, 0x10 },
++	{ 0x900b4, 0x2a8 },
++	{ 0x900b5, 0x129 },
++	{ 0x900b6, 0x8 },
++	{ 0x900b7, 0x370 },
++	{ 0x900b8, 0x129 },
++	{ 0x900b9, 0xa },
++	{ 0x900ba, 0x3c8 },
++	{ 0x900bb, 0x1a9 },
++	{ 0x900bc, 0xc },
++	{ 0x900bd, 0x408 },
++	{ 0x900be, 0x199 },
++	{ 0x900bf, 0x14 },
++	{ 0x900c0, 0x790 },
++	{ 0x900c1, 0x11a },
++	{ 0x900c2, 0x8 },
++	{ 0x900c3, 0x4 },
++	{ 0x900c4, 0x18 },
++	{ 0x900c5, 0xe },
++	{ 0x900c6, 0x408 },
++	{ 0x900c7, 0x199 },
++	{ 0x900c8, 0x8 },
++	{ 0x900c9, 0x8568 },
++	{ 0x900ca, 0x108 },
++	{ 0x900cb, 0x18 },
++	{ 0x900cc, 0x790 },
++	{ 0x900cd, 0x16a },
++	{ 0x900ce, 0x8 },
++	{ 0x900cf, 0x1d8 },
++	{ 0x900d0, 0x169 },
++	{ 0x900d1, 0x10 },
++	{ 0x900d2, 0x8558 },
++	{ 0x900d3, 0x168 },
++	{ 0x900d4, 0x70 },
++	{ 0x900d5, 0x788 },
++	{ 0x900d6, 0x16a },
++	{ 0x900d7, 0x1ff8 },
++	{ 0x900d8, 0x85a8 },
++	{ 0x900d9, 0x1e8 },
++	{ 0x900da, 0x50 },
++	{ 0x900db, 0x798 },
++	{ 0x900dc, 0x16a },
++	{ 0x900dd, 0x60 },
++	{ 0x900de, 0x7a0 },
++	{ 0x900df, 0x16a },
++	{ 0x900e0, 0x8 },
++	{ 0x900e1, 0x8310 },
++	{ 0x900e2, 0x168 },
++	{ 0x900e3, 0x8 },
++	{ 0x900e4, 0xa310 },
++	{ 0x900e5, 0x168 },
++	{ 0x900e6, 0xa },
++	{ 0x900e7, 0x408 },
++	{ 0x900e8, 0x169 },
++	{ 0x900e9, 0x6e },
++	{ 0x900ea, 0x0 },
++	{ 0x900eb, 0x68 },
++	{ 0x900ec, 0x0 },
++	{ 0x900ed, 0x408 },
++	{ 0x900ee, 0x169 },
++	{ 0x900ef, 0x0 },
++	{ 0x900f0, 0x8310 },
++	{ 0x900f1, 0x168 },
++	{ 0x900f2, 0x0 },
++	{ 0x900f3, 0xa310 },
++	{ 0x900f4, 0x168 },
++	{ 0x900f5, 0x1ff8 },
++	{ 0x900f6, 0x85a8 },
++	{ 0x900f7, 0x1e8 },
++	{ 0x900f8, 0x68 },
++	{ 0x900f9, 0x798 },
++	{ 0x900fa, 0x16a },
++	{ 0x900fb, 0x78 },
++	{ 0x900fc, 0x7a0 },
++	{ 0x900fd, 0x16a },
++	{ 0x900fe, 0x68 },
++	{ 0x900ff, 0x790 },
++	{ 0x90100, 0x16a },
++	{ 0x90101, 0x8 },
++	{ 0x90102, 0x8b10 },
++	{ 0x90103, 0x168 },
++	{ 0x90104, 0x8 },
++	{ 0x90105, 0xab10 },
++	{ 0x90106, 0x168 },
++	{ 0x90107, 0xa },
++	{ 0x90108, 0x408 },
++	{ 0x90109, 0x169 },
++	{ 0x9010a, 0x58 },
++	{ 0x9010b, 0x0 },
++	{ 0x9010c, 0x68 },
++	{ 0x9010d, 0x0 },
++	{ 0x9010e, 0x408 },
++	{ 0x9010f, 0x169 },
++	{ 0x90110, 0x0 },
++	{ 0x90111, 0x8b10 },
++	{ 0x90112, 0x168 },
++	{ 0x90113, 0x1 },
++	{ 0x90114, 0xab10 },
++	{ 0x90115, 0x168 },
++	{ 0x90116, 0x0 },
++	{ 0x90117, 0x1d8 },
++	{ 0x90118, 0x169 },
++	{ 0x90119, 0x80 },
++	{ 0x9011a, 0x790 },
++	{ 0x9011b, 0x16a },
++	{ 0x9011c, 0x18 },
++	{ 0x9011d, 0x7aa },
++	{ 0x9011e, 0x6a },
++	{ 0x9011f, 0xa },
++	{ 0x90120, 0x0 },
++	{ 0x90121, 0x1e9 },
++	{ 0x90122, 0x8 },
++	{ 0x90123, 0x8080 },
++	{ 0x90124, 0x108 },
++	{ 0x90125, 0xf },
++	{ 0x90126, 0x408 },
++	{ 0x90127, 0x169 },
++	{ 0x90128, 0xc },
++	{ 0x90129, 0x0 },
++	{ 0x9012a, 0x68 },
++	{ 0x9012b, 0x9 },
++	{ 0x9012c, 0x0 },
++	{ 0x9012d, 0x1a9 },
++	{ 0x9012e, 0x0 },
++	{ 0x9012f, 0x408 },
++	{ 0x90130, 0x169 },
++	{ 0x90131, 0x0 },
++	{ 0x90132, 0x8080 },
++	{ 0x90133, 0x108 },
++	{ 0x90134, 0x8 },
++	{ 0x90135, 0x7aa },
++	{ 0x90136, 0x6a },
++	{ 0x90137, 0x0 },
++	{ 0x90138, 0x8568 },
++	{ 0x90139, 0x108 },
++	{ 0x9013a, 0xb7 },
++	{ 0x9013b, 0x790 },
++	{ 0x9013c, 0x16a },
++	{ 0x9013d, 0x1f },
++	{ 0x9013e, 0x0 },
++	{ 0x9013f, 0x68 },
++	{ 0x90140, 0x8 },
++	{ 0x90141, 0x8558 },
++	{ 0x90142, 0x168 },
++	{ 0x90143, 0xf },
++	{ 0x90144, 0x408 },
++	{ 0x90145, 0x169 },
++	{ 0x90146, 0xd },
++	{ 0x90147, 0x0 },
++	{ 0x90148, 0x68 },
++	{ 0x90149, 0x0 },
++	{ 0x9014a, 0x408 },
++	{ 0x9014b, 0x169 },
++	{ 0x9014c, 0x0 },
++	{ 0x9014d, 0x8558 },
++	{ 0x9014e, 0x168 },
++	{ 0x9014f, 0x8 },
++	{ 0x90150, 0x3c8 },
++	{ 0x90151, 0x1a9 },
++	{ 0x90152, 0x3 },
++	{ 0x90153, 0x370 },
++	{ 0x90154, 0x129 },
++	{ 0x90155, 0x20 },
++	{ 0x90156, 0x2aa },
++	{ 0x90157, 0x9 },
++	{ 0x90158, 0x8 },
++	{ 0x90159, 0xe8 },
++	{ 0x9015a, 0x109 },
++	{ 0x9015b, 0x0 },
++	{ 0x9015c, 0x8140 },
++	{ 0x9015d, 0x10c },
++	{ 0x9015e, 0x10 },
++	{ 0x9015f, 0x8138 },
++	{ 0x90160, 0x104 },
++	{ 0x90161, 0x8 },
++	{ 0x90162, 0x448 },
++	{ 0x90163, 0x109 },
++	{ 0x90164, 0xf },
++	{ 0x90165, 0x7c0 },
++	{ 0x90166, 0x109 },
++	{ 0x90167, 0x0 },
++	{ 0x90168, 0xe8 },
++	{ 0x90169, 0x109 },
++	{ 0x9016a, 0x47 },
++	{ 0x9016b, 0x630 },
++	{ 0x9016c, 0x109 },
++	{ 0x9016d, 0x8 },
++	{ 0x9016e, 0x618 },
++	{ 0x9016f, 0x109 },
++	{ 0x90170, 0x8 },
++	{ 0x90171, 0xe0 },
++	{ 0x90172, 0x109 },
++	{ 0x90173, 0x0 },
++	{ 0x90174, 0x7c8 },
++	{ 0x90175, 0x109 },
++	{ 0x90176, 0x8 },
++	{ 0x90177, 0x8140 },
++	{ 0x90178, 0x10c },
++	{ 0x90179, 0x0 },
++	{ 0x9017a, 0x478 },
++	{ 0x9017b, 0x109 },
++	{ 0x9017c, 0x0 },
++	{ 0x9017d, 0x1 },
++	{ 0x9017e, 0x8 },
++	{ 0x9017f, 0x8 },
++	{ 0x90180, 0x4 },
++	{ 0x90181, 0x0 },
++	{ 0x90006, 0x8 },
++	{ 0x90007, 0x7c8 },
++	{ 0x90008, 0x109 },
++	{ 0x90009, 0x0 },
++	{ 0x9000a, 0x400 },
++	{ 0x9000b, 0x106 },
++	{ 0xd00e7, 0x400 },
++	{ 0x90017, 0x0 },
++	{ 0x9001f, 0x29 },
++	{ 0x90026, 0x68 },
++	{ 0x400d0, 0x0 },
++	{ 0x400d1, 0x101 },
++	{ 0x400d2, 0x105 },
++	{ 0x400d3, 0x107 },
++	{ 0x400d4, 0x10f },
++	{ 0x400d5, 0x202 },
++	{ 0x400d6, 0x20a },
++	{ 0x400d7, 0x20b },
++	{ 0x2003a, 0x2 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x2000b, 0x4b },
++	{ 0x2000c, 0x96 },
++	{ 0x2000d, 0x5dc },
++#else
++	{ 0x200be, 0x3 },
++	{ 0x2000b, 0x7d },
++	{ 0x2000c, 0xfa },
++	{ 0x2000d, 0x9c4 },
++#endif
++	{ 0x2000e, 0x2c },
++	{ 0x12000b, 0xc },
++	{ 0x12000c, 0x19 },
++	{ 0x12000d, 0xfa },
++	{ 0x12000e, 0x10 },
++	{ 0x22000b, 0x3 },
++	{ 0x22000c, 0x6 },
++	{ 0x22000d, 0x3e },
++	{ 0x22000e, 0x10 },
++	{ 0x9000c, 0x0 },
++	{ 0x9000d, 0x173 },
++	{ 0x9000e, 0x60 },
++	{ 0x9000f, 0x6110 },
++	{ 0x90010, 0x2152 },
++	{ 0x90011, 0xdfbd },
++	{ 0x90012, 0x2060 },
++	{ 0x90013, 0x6152 },
++	{ 0x20010, 0x5a },
++	{ 0x20011, 0x3 },
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	{ 0x120010, 0x5a },
++	{ 0x120011, 0x3 },
++	{ 0x220010, 0x5a },
++	{ 0x220011, 0x3 },
++#endif
++	{ 0x40080, 0xe0 },
++	{ 0x40081, 0x12 },
++	{ 0x40082, 0xe0 },
++	{ 0x40083, 0x12 },
++	{ 0x40084, 0xe0 },
++	{ 0x40085, 0x12 },
++	{ 0x140080, 0xe0 },
++	{ 0x140081, 0x12 },
++	{ 0x140082, 0xe0 },
++	{ 0x140083, 0x12 },
++	{ 0x140084, 0xe0 },
++	{ 0x140085, 0x12 },
++	{ 0x240080, 0xe0 },
++	{ 0x240081, 0x12 },
++	{ 0x240082, 0xe0 },
++	{ 0x240083, 0x12 },
++	{ 0x240084, 0xe0 },
++	{ 0x240085, 0x12 },
++	{ 0x400fd, 0xf },
++	{ 0x10011, 0x1 },
++	{ 0x10012, 0x1 },
++	{ 0x10013, 0x180 },
++	{ 0x10018, 0x1 },
++	{ 0x10002, 0x6209 },
++	{ 0x100b2, 0x1 },
++	{ 0x101b4, 0x1 },
++	{ 0x102b4, 0x1 },
++	{ 0x103b4, 0x1 },
++	{ 0x104b4, 0x1 },
++	{ 0x105b4, 0x1 },
++	{ 0x106b4, 0x1 },
++	{ 0x107b4, 0x1 },
++	{ 0x108b4, 0x1 },
++	{ 0x11011, 0x1 },
++	{ 0x11012, 0x1 },
++	{ 0x11013, 0x180 },
++	{ 0x11018, 0x1 },
++	{ 0x11002, 0x6209 },
++	{ 0x110b2, 0x1 },
++	{ 0x111b4, 0x1 },
++	{ 0x112b4, 0x1 },
++	{ 0x113b4, 0x1 },
++	{ 0x114b4, 0x1 },
++	{ 0x115b4, 0x1 },
++	{ 0x116b4, 0x1 },
++	{ 0x117b4, 0x1 },
++	{ 0x118b4, 0x1 },
++	{ 0x12011, 0x1 },
++	{ 0x12012, 0x1 },
++	{ 0x12013, 0x180 },
++	{ 0x12018, 0x1 },
++	{ 0x12002, 0x6209 },
++	{ 0x120b2, 0x1 },
++	{ 0x121b4, 0x1 },
++	{ 0x122b4, 0x1 },
++	{ 0x123b4, 0x1 },
++	{ 0x124b4, 0x1 },
++	{ 0x125b4, 0x1 },
++	{ 0x126b4, 0x1 },
++	{ 0x127b4, 0x1 },
++	{ 0x128b4, 0x1 },
++	{ 0x13011, 0x1 },
++	{ 0x13012, 0x1 },
++	{ 0x13013, 0x180 },
++	{ 0x13018, 0x1 },
++	{ 0x13002, 0x6209 },
++	{ 0x130b2, 0x1 },
++	{ 0x131b4, 0x1 },
++	{ 0x132b4, 0x1 },
++	{ 0x133b4, 0x1 },
++	{ 0x134b4, 0x1 },
++	{ 0x135b4, 0x1 },
++	{ 0x136b4, 0x1 },
++	{ 0x137b4, 0x1 },
++	{ 0x138b4, 0x1 },
++	{ 0x20089, 0x1 },
++	{ 0x20088, 0x19 },
++	{ 0xc0080, 0x2 },
++	{ 0xd0000, 0x1 }
++};
++
++struct dram_fsp_msg ddr_dram_fsp_msg[] = {
++	{
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++		/* P0 2400mts 1D */
++		.drate = 2400,
++#else
++		/* P0 4000mts 1D */
++		.drate = 4000,
++#endif
++		.fw_type = FW_1D_IMAGE,
++		.fsp_cfg = ddr_fsp0_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_cfg),
++	},
++	{
++		/* P1 400mts 1D */
++		.drate = 400,
++		.fw_type = FW_1D_IMAGE,
++		.fsp_cfg = ddr_fsp1_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp1_cfg),
++	},
++	{
++		/* P2 100mts 1D */
++		.drate = 100,
++		.fw_type = FW_1D_IMAGE,
++		.fsp_cfg = ddr_fsp2_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp2_cfg),
++	},
++	{
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++		/* P0 2400mts 2D */
++		.drate = 2400,
++#else
++		/* P0 4000mts 2D */
++		.drate = 4000,
++#endif
++		.fw_type = FW_2D_IMAGE,
++		.fsp_cfg = ddr_fsp0_2d_cfg,
++		.fsp_cfg_num = ARRAY_SIZE(ddr_fsp0_2d_cfg),
++	},
++};
++
++/* ddr timing config params */
++struct dram_timing_info dram_timing = {
++	.ddrc_cfg = ddr_ddrc_cfg,
++	.ddrc_cfg_num = ARRAY_SIZE(ddr_ddrc_cfg),
++	.ddrphy_cfg = ddr_ddrphy_cfg,
++	.ddrphy_cfg_num = ARRAY_SIZE(ddr_ddrphy_cfg),
++	.fsp_msg = ddr_dram_fsp_msg,
++	.fsp_msg_num = ARRAY_SIZE(ddr_dram_fsp_msg),
++	.ddrphy_trained_csr = ddr_ddrphy_trained_csr,
++	.ddrphy_trained_csr_num = ARRAY_SIZE(ddr_ddrphy_trained_csr),
++	.ddrphy_pie = ddr_phy_pie,
++	.ddrphy_pie_num = ARRAY_SIZE(ddr_phy_pie),
++#ifdef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++	.fsp_table = { 2400, 400, 100, },
++#else
++	.fsp_table = { 4000, 400, 100, },
++#endif
++};
++
++#ifndef CONFIG_IMX8M_LPDDR4_FREQ0_2400MTS
++#ifdef CONFIG_IMX8M_DRAM_INLINE_ECC
++void board_dram_ecc_scrub(void)
++{
++	ddrc_inline_ecc_scrub(0x0, 0x3ffffff);
++	ddrc_inline_ecc_scrub(0x20000000, 0x23ffffff);
++	ddrc_inline_ecc_scrub(0x40000000, 0x43ffffff);
++	ddrc_inline_ecc_scrub(0x4000000, 0x7ffffff);
++	ddrc_inline_ecc_scrub(0x24000000, 0x27ffffff);
++	ddrc_inline_ecc_scrub(0x44000000, 0x47ffffff);
++	ddrc_inline_ecc_scrub(0x8000000, 0xbffffff);
++	ddrc_inline_ecc_scrub(0x28000000, 0x2bffffff);
++	ddrc_inline_ecc_scrub(0x48000000, 0x4bffffff);
++	ddrc_inline_ecc_scrub(0xc000000, 0xfffffff);
++	ddrc_inline_ecc_scrub(0x2c000000, 0x2fffffff);
++	ddrc_inline_ecc_scrub(0x4c000000, 0x4fffffff);
++	ddrc_inline_ecc_scrub(0x10000000, 0x13ffffff);
++	ddrc_inline_ecc_scrub(0x30000000, 0x33ffffff);
++	ddrc_inline_ecc_scrub(0x50000000, 0x53ffffff);
++	ddrc_inline_ecc_scrub(0x14000000, 0x17ffffff);
++	ddrc_inline_ecc_scrub(0x34000000, 0x37ffffff);
++	ddrc_inline_ecc_scrub(0x54000000, 0x57ffffff);
++	ddrc_inline_ecc_scrub(0x18000000, 0x1bffffff);
++	ddrc_inline_ecc_scrub(0x38000000, 0x3bffffff);
++	ddrc_inline_ecc_scrub(0x58000000, 0x5bffffff);
++	ddrc_inline_ecc_scrub_end(0x0, 0x5fffffff);
++}
++#endif
++#endif
+diff --git a/board/olimex/imx8mp_olimex_som_evb/spl.c b/board/olimex/imx8mp_olimex_som_evb/spl.c
+new file mode 100644
+index 00000000..5b4aac42
+--- /dev/null
++++ b/board/olimex/imx8mp_olimex_som_evb/spl.c
+@@ -0,0 +1,121 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright 2018-2019, 2021 NXP
++ *
++ */
++
++#include <hang.h>
++#include <init.h>
++#include <log.h>
++#include <power/pmic.h>
++#include <power/pca9450.h>
++#include <spl.h>
++#include <asm/arch/clock.h>
++#include <asm/arch/ddr.h>
++#include <asm/arch/sys_proto.h>
++#include <asm/mach-imx/boot_mode.h>
++
++int spl_board_boot_device(enum boot_device boot_dev_spl)
++{
++	return BOOT_DEVICE_BOOTROM;
++}
++
++void spl_dram_init(void)
++{
++	ddr_init(&dram_timing);
++}
++
++void spl_board_init(void)
++{
++	arch_misc_init();
++
++	/*
++	 * Set GIC clock to 500Mhz for OD VDD_SOC. Kernel driver does
++	 * not allow to change it. Should set the clock after PMIC
++	 * setting done. Default is 400Mhz (system_pll1_800m with div = 2)
++	 * set by ROM for ND VDD_SOC
++	 */
++	clock_enable(CCGR_GIC, 0);
++	clock_set_target_val(GIC_CLK_ROOT, CLK_ROOT_ON | CLK_ROOT_SOURCE_SEL(5));
++	clock_enable(CCGR_GIC, 1);
++
++	puts("Normal Boot\n");
++}
++
++#if CONFIG_IS_ENABLED(DM_PMIC_PCA9450)
++int power_init_board(void)
++{
++	struct udevice *dev;
++	int ret;
++
++	ret = pmic_get("pmic@25", &dev);
++	if (ret == -ENODEV) {
++		puts("No pmic@25\n");
++		return 0;
++	}
++	if (ret < 0)
++		return ret;
++
++	/* BUCKxOUT_DVS0/1 control BUCK123 output */
++	pmic_reg_write(dev, PCA9450_BUCK123_DVS, 0x29);
++
++	/*
++	 * Increase VDD_SOC to typical value 0.95V before first
++	 * DRAM access, set DVS1 to 0.85V for suspend.
++	 * Enable DVS control through PMIC_STBY_REQ and
++	 * set B1_ENMODE=1 (ON by PMIC_ON_REQ=H)
++	 */
++	if (CONFIG_IS_ENABLED(IMX8M_VDD_SOC_850MV))
++		pmic_reg_write(dev, PCA9450_BUCK1OUT_DVS0, 0x14);
++	else
++		pmic_reg_write(dev, PCA9450_BUCK1OUT_DVS0, 0x1C);
++
++	pmic_reg_write(dev, PCA9450_BUCK1OUT_DVS1, 0x14);
++	pmic_reg_write(dev, PCA9450_BUCK1CTRL, 0x59);
++
++	/*
++	 * Kernel uses OD/OD freq for SOC.
++	 * To avoid timing risk from SOC to ARM,increase VDD_ARM to OD
++	 * voltage 0.95V.
++	 */
++
++	pmic_reg_write(dev, PCA9450_BUCK2OUT_DVS0, 0x1C);
++
++	return 0;
++}
++#endif
++
++#ifdef CONFIG_SPL_LOAD_FIT
++int board_fit_config_name_match(const char *name)
++{
++	/* Just empty function now - can't decide what to choose */
++	debug("%s: %s\n", __func__, name);
++
++	return 0;
++}
++#endif
++
++/* Do not use BSS area in this phase */
++void board_init_f(ulong dummy)
++{
++	int ret;
++
++	arch_cpu_init();
++
++	init_uart_clk(1);
++
++	ret = spl_early_init();
++	if (ret) {
++		debug("spl_init() failed: %d\n", ret);
++		hang();
++	}
++
++	preloader_console_init();
++
++	enable_tzc380();
++
++	power_init_board();
++
++	/* DDR initialization */
++	spl_dram_init();
++}
+diff --git a/configs/imx8mp_olimex_som_evb_defconfig b/configs/imx8mp_olimex_som_evb_defconfig
+new file mode 100644
+index 00000000..5f2beeb7
+--- /dev/null
++++ b/configs/imx8mp_olimex_som_evb_defconfig
+@@ -0,0 +1,165 @@
++CONFIG_ARM=y
++CONFIG_ARCH_IMX8M=y
++CONFIG_TEXT_BASE=0x40200000
++CONFIG_SYS_MALLOC_LEN=0x2000000
++CONFIG_SPL_GPIO=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_ENV_SIZE=0x4000
++CONFIG_ENV_OFFSET=0x200000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="freescale/imx8mp-olimex-som-evb"
++CONFIG_TARGET_IMX8MP_OLIMEX_SOM_EVB=y
++CONFIG_SYS_MONITOR_LEN=524288
++CONFIG_SPL_MMC=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SPL_DRIVERS_MISC=y
++CONFIG_SPL_STACK=0x960000
++CONFIG_SPL_TEXT_BASE=0x920000
++CONFIG_SPL_HAS_BSS_LINKER_SECTION=y
++CONFIG_SPL_BSS_START_ADDR=0x98fc00
++CONFIG_SPL_BSS_MAX_SIZE=0x400
++CONFIG_SYS_BOOTM_LEN=0x2000000
++CONFIG_SYS_LOAD_ADDR=0x40480000
++CONFIG_SPL=y
++CONFIG_ENV_OFFSET_REDUND=0x20400
++CONFIG_SPL_IMX_ROMAPI_LOADADDR=0x48000000
++CONFIG_EFI_MM_COMM_TEE=y
++CONFIG_EFI_VAR_BUF_SIZE=139264
++CONFIG_EFI_RUNTIME_UPDATE_CAPSULE=y
++CONFIG_EFI_CAPSULE_ON_DISK=y
++CONFIG_EFI_CAPSULE_FIRMWARE_RAW=y
++CONFIG_FIT=y
++CONFIG_FIT_EXTERNAL_OFFSET=0x3000
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_OF_SYSTEM_SETUP=y
++CONFIG_BOOTCOMMAND="bootflow scan -lb; run bsp_bootcmd"
++CONFIG_DEFAULT_FDT_FILE="imx8mp-olimex-som-evb.dtb"
++CONFIG_SYS_CBSIZE=2048
++CONFIG_SYS_PBSIZE=2074
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_SPL_MAX_SIZE=0x26000
++CONFIG_SPL_BOARD_INIT=y
++CONFIG_SPL_BOOTROM_SUPPORT=y
++CONFIG_SPL_SYS_MALLOC_SIMPLE=y
++# CONFIG_SPL_SHARES_INIT_SP_ADDR is not set
++CONFIG_SPL_HAVE_INIT_STACK=y
++CONFIG_SPL_SYS_MALLOC=y
++CONFIG_SPL_HAS_CUSTOM_MALLOC_START=y
++CONFIG_SPL_CUSTOM_SYS_MALLOC_ADDR=0x42200000
++CONFIG_SPL_SYS_MALLOC_SIZE=0x80000
++CONFIG_SPL_SYS_MMCSD_RAW_MODE=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR=0x300
++CONFIG_SPL_I2C=y
++CONFIG_SPL_POWER=y
++CONFIG_SPL_WATCHDOG=y
++CONFIG_SYS_PROMPT="u-boot=> "
++CONFIG_CMD_CPU=y
++# CONFIG_CMD_EXPORTENV is not set
++# CONFIG_CMD_IMPORTENV is not set
++CONFIG_CMD_NVEDIT_EFI=y
++# CONFIG_CMD_CRC32 is not set
++CONFIG_CMD_CLK=y
++CONFIG_CMD_DFU=y
++CONFIG_CMD_FUSE=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_OPTEE=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_SDP=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_EFIDEBUG=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_CMD_EXT4_WRITE=y
++CONFIG_OF_CONTROL=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_ENV_OVERWRITE=y
++# CONFIG_ENV_IS_IN_MMC is not set
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_IS_NOWHERE=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_MMC_DEVICE_INDEX=1
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_USE_ETHPRIME=y
++CONFIG_ETHPRIME="eth1"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_SPL_DM=y
++CONFIG_CLK_COMPOSITE_CCF=y
++CONFIG_CLK_IMX8MP=y
++CONFIG_DFU_MMC=y
++CONFIG_USB_FUNCTION_FASTBOOT=y
++CONFIG_FASTBOOT_BUF_ADDR=0x42800000
++CONFIG_FASTBOOT_BUF_SIZE=0x20000000
++CONFIG_FASTBOOT_FLASH=y
++CONFIG_FASTBOOT_UUU_SUPPORT=y
++CONFIG_FASTBOOT_FLASH_MMC_DEV=2
++CONFIG_FASTBOOT_MMC_BOOT_SUPPORT=y
++CONFIG_FASTBOOT_MMC_USER_SUPPORT=y
++CONFIG_MXC_GPIO=y
++CONFIG_DM_PCA953X=y
++CONFIG_DM_I2C=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_MMC_IO_VOLTAGE=y
++CONFIG_MMC_UHS_SUPPORT=y
++CONFIG_MMC_HS400_ES_SUPPORT=y
++CONFIG_MMC_HS400_SUPPORT=y
++CONFIG_FSL_USDHC=y
++CONFIG_PHY_ANEG_TIMEOUT=20000
++CONFIG_DM_ETH_PHY=y
++CONFIG_PHY_GIGE=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_DWC_ETH_QOS_IMX=y
++CONFIG_FEC_MXC=y
++CONFIG_MII=y
++CONFIG_PHY=y
++CONFIG_PHY_IMX8MQ_USB=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_PINCTRL_IMX8M=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_IMX8M_POWER_DOMAIN=y
++CONFIG_IMX8MP_HSIOMIX_BLKCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_DM_PMIC_PCA9450=y
++CONFIG_SPL_DM_PMIC_PCA9450=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_PCA9450=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_SERIAL=y
++CONFIG_MXC_UART=y
++CONFIG_SYSRESET=y
++CONFIG_SPL_SYSRESET=y
++CONFIG_SYSRESET_PSCI=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_TEE=y
++CONFIG_OPTEE=y
++CONFIG_USB=y
++# CONFIG_SPL_DM_USB is not set
++CONFIG_DM_USB_GADGET=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_XHCI_DWC3_OF_SIMPLE=y
++CONFIG_USB_EHCI_HCD=y
++# CONFIG_USB_EHCI_MX7 is not set
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_USB_GADGET_MANUFACTURER="FSL"
++CONFIG_USB_GADGET_VENDOR_NUM=0x0525
++CONFIG_USB_GADGET_PRODUCT_NUM=0xa4a5
++CONFIG_IMX_WATCHDOG=y
++CONFIG_SHA384=y
++CONFIG_DM_THERMAL=y
++CONFIG_NXP_TMU=y
++CONFIG_USB_TCPC=y
++CONFIG_PHY_MICREL=y
++CONFIG_PHY_MICREL_KSZ90X1=y
+diff --git a/dts/upstream/src/arm64/freescale/imx8mp-olimex-som-evb.dts b/dts/upstream/src/arm64/freescale/imx8mp-olimex-som-evb.dts
+new file mode 100644
+index 00000000..ae3c6d16
+--- /dev/null
++++ b/dts/upstream/src/arm64/freescale/imx8mp-olimex-som-evb.dts
+@@ -0,0 +1,843 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2019 NXP
++ * Copyright 2025 Zoltan HERPAI <wigyori@uid0.hu>
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/usb/pd.h>
++#include <dt-bindings/phy/phy-imx8-pcie.h>
++#include <dt-bindings/leds/common.h>
++#include "imx8mp.dtsi"
++
++/ {
++	model = "Olimex i.MX8MP-SOM-EVB";
++	compatible = "olimex,imx8mp-som-evb", "fsl,imx8mp";
++
++	chosen {
++		stdout-path = &uart2;
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpio_led>;
++
++		status {
++			color = <LED_COLOR_ID_YELLOW>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio3 16 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x0 0x40000000 0 0xc0000000>,
++		      <0x1 0x00000000 0 0x40000000>;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		regulator-name = "VSD_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	reg_audio_codec: regulator-audio-codec {
++		compatible = "regulator-fixed";
++		regulator-name = "es8328-power";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio4 29 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	reg_pcie0: regulator-pcie {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_pcie0_reg>;
++		regulator-name = "MPCIE_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio2 6 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	pcie0_refclk: clock-pcie0 {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <100000000>;
++	};
++
++	reg_usb1_host_vbus: regulator-usb1-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb1_host_vbus";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usb1_vbus>;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "es8328-audio";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,frame-master = <&cpudai>;
++		simple-audio-card,bitclock-master = <&cpudai>;
++		simple-audio-card,widgets =
++			"Headphone", "Headphone Jack",
++			"Speaker", "External Speaker",
++			"Microphone", "Mic Jack";
++		simple-audio-card,routing =
++			"Headphone Jack", "HP_L",
++			"Headphone Jack", "HP_R",
++			"External Speaker", "SPK_LP",
++			"External Speaker", "SPK_LN",
++			"External Speaker", "SPK_RP",
++			"External Speaker", "SPK_RN",
++			"LINPUT1", "Mic Jack",
++			"LINPUT3", "Mic Jack",
++			"Mic Jack", "MICB";
++
++		cpudai: simple-audio-card,cpu {
++			sound-dai = <&sai3>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&es8328>;
++		};
++	};
++};
++
++&A53_0 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_1 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_2 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_3 {
++	cpu-supply = <&buck2>;
++};
++
++&dsp {
++	status = "okay";
++};
++
++&pwm1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm1>;
++	status = "okay";
++};
++
++&pwm2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm2>;
++	status = "okay";
++};
++
++&pwm4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pwm4>;
++	status = "okay";
++};
++
++&ecspi2 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	fsl,spi-num-chipselects = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi2 &pinctrl_ecspi2_cs>;
++	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
++	status = "okay";
++
++	spidev1: spi@0 {
++		reg = <0>;
++		compatible = "rohm,dh2228fv";
++		spi-max-frequency = <500000>;
++	};
++};
++
++&eqos {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_eqos>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy0>;
++	fsl,magic-packet;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		ethphy0: ethernet-phy@3 {
++			reset-gpios = <&gpio4 22 GPIO_ACTIVE_LOW>;
++			reset-assert-us = <150000>;
++			reset-deassert-us = <10000>;
++
++			compatible = "ethernet-phy-ieee802.3-c22";
++			eee-broken-100tx;
++			eee-broken-1000t;
++
++			reg = <3>;
++		};
++	};
++};
++
++&fec {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_fec>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy1>;
++	fsl,magic-packet;
++	status = "okay";
++
++	mdio {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		ethphy1: ethernet-phy@7 {
++			reset-gpios = <&gpio4 2 GPIO_ACTIVE_LOW>;
++			reset-assert-us = <150000>;
++			reset-deassert-us = <10000>;
++
++			compatible = "ethernet-phy-ieee802.3-c22";
++			reg = <7>;
++		};
++	};
++};
++
++&flexspi {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexspi0>;
++	status = "okay";
++
++	flash0: flash@0 {
++		compatible = "jedec,spi-nor", "winbond,w25q128";
++		reg = <0>;
++		spi-rx-bus-width = <4>;
++		spi-max-frequency = <108000000>;
++		#address-cells = <1>;
++		#size-cells = <1>;
++	};
++};
++
++&flexcan1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexcan1>;
++	status = "okay";
++};
++
++&flexcan2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_flexcan2>;
++	status = "okay";
++};
++
++&i2c1 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c1>;
++	status = "okay";
++
++	pmic: pmic@25 {
++		reg = <0x25>;
++		compatible = "nxp,pca9450c";
++		/* PMIC PCA9450 PMIC_nINT GPIO1_IO3 */
++		pinctrl-0 = <&pinctrl_pmic>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <3 GPIO_ACTIVE_LOW>;
++
++		regulators {
++			buck1: BUCK1 {
++				regulator-name = "BUCK1";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <2187500>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-ramp-delay = <3125>;
++			};
++
++			buck2: BUCK2 {
++				regulator-name = "BUCK2";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <2187500>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-ramp-delay = <3125>;
++				nxp,dvs-run-voltage = <950000>;
++				nxp,dvs-standby-voltage = <850000>;
++			};
++
++			buck4: BUCK4{
++				regulator-name = "BUCK4";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <3400000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			buck5: BUCK5{
++				regulator-name = "BUCK5";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <3400000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			buck6: BUCK6 {
++				regulator-name = "BUCK6";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <3400000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo1: LDO1 {
++				regulator-name = "LDO1";
++				regulator-min-microvolt = <1600000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo2: LDO2 {
++				regulator-name = "LDO2";
++				regulator-min-microvolt = <800000>;
++				regulator-max-microvolt = <1150000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo3: LDO3 {
++				regulator-name = "LDO3";
++				regulator-min-microvolt = <800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo4: LDO4 {
++				regulator-name = "LDO4";
++				regulator-min-microvolt = <800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo5: LDO5 {
++				regulator-name = "LDO5";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++		};
++	};
++
++	eeprom: eeprom@50 {
++		compatible = "atmel,24c16";
++		reg = <0x50>;
++		pagesize = <16>;
++	};
++};
++
++&i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	status = "okay";
++
++	es8328: es8328@11 {
++		compatible = "everest,es8328";
++		reg = <0x11>;
++		DVDD-supply = <&reg_audio_codec>;
++		AVDD-supply = <&reg_audio_codec>;
++		PVDD-supply = <&reg_audio_codec>;
++		HPVDD-supply = <&reg_audio_codec>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_sai3>;
++		clocks = <&audio_blk_ctrl IMX8MP_CLK_AUDIOMIX_SAI3_MCLK1>;
++		clock-names = "mclk";
++	};
++};
++
++&lcdif2 {
++	status = "okay";
++};
++
++&snvs_pwrkey {
++	status = "okay";
++};
++
++&pcie {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie0>;
++	reset-gpio = <&gpio2 7 GPIO_ACTIVE_LOW>;
++	vpcie-supply = <&reg_pcie0>;
++	status = "okay";
++};
++
++&pcie_phy {
++	clocks = <&pcie0_refclk>;
++	clock-names = "ref";
++	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
++	fsl,clkreq-unsupported;
++	status = "okay";
++};
++
++&sai3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_sai3>;
++	assigned-clocks = <&clk IMX8MP_CLK_SAI3>;
++	assigned-clock-parents = <&clk IMX8MP_AUDIO_PLL1_OUT>;
++	assigned-clock-rates = <12288000>;
++	fsl,sai-mclk-direction-output;
++	status = "okay";
++};
++
++&sdma2 {
++	status = "okay";
++};
++
++&uart1 { /* BT */
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	assigned-clocks = <&clk IMX8MP_CLK_UART1>;
++	assigned-clock-parents = <&clk IMX8MP_SYS_PLL1_80M>;
++	fsl,uart-has-rtscts;
++	status = "okay";
++};
++
++&uart2 {
++	/* console */
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart2>;
++	status = "okay";
++};
++
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart3>;
++	assigned-clocks = <&clk IMX8MP_CLK_UART3>;
++	assigned-clock-parents = <&clk IMX8MP_SYS_PLL1_80M>;
++	fsl,uart-has-rtscts;
++	status = "okay";
++};
++
++&usb3_phy0 {
++	fsl,phy-tx-vref-tune = <0xb>;
++	fsl,phy-tx-preemp-amp-tune = <3>;
++	status = "okay";
++};
++
++&usb3_0 {
++	status = "okay";
++};
++
++&usb_dwc3_0 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb3_phy1 {
++	vbus-supply = <&reg_usb1_host_vbus>;
++	fsl,phy-tx-preemp-amp-tune = <3>;
++	fsl,phy-tx-vref-tune = <0xb>;
++	status = "okay";
++};
++
++&usb3_1 {
++	status = "okay";
++};
++
++&usb_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usdhc2 {
++	assigned-clocks = <&clk IMX8MP_CLK_USDHC2>;
++	assigned-clock-rates = <400000000>;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	bus-width = <4>;
++	status = "okay";
++};
++
++&usdhc3 {
++	assigned-clocks = <&clk IMX8MP_CLK_USDHC3>;
++	assigned-clock-rates = <400000000>;
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc3>;
++	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
++	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
++	bus-width = <8>;
++	non-removable;
++	status = "okay";
++};
++
++&wdog1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_wdog>;
++	fsl,ext-reset-output;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_hog>;
++
++	pinctrl_hog: hoggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_HDMI_DDC_SCL__HDMIMIX_HDMI_SCL	0x400001c3
++			MX8MP_IOMUXC_HDMI_DDC_SDA__HDMIMIX_HDMI_SDA	0x400001c3
++			MX8MP_IOMUXC_HDMI_HPD__HDMIMIX_HDMI_HPD		0x40000019
++			MX8MP_IOMUXC_HDMI_CEC__HDMIMIX_HDMI_CEC		0x40000019
++		>;
++	};
++
++	pinctrl_pwm1: pwm1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO01__PWM1_OUT	0x116
++		>;
++	};
++
++	pinctrl_pwm2: pwm2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO11__PWM2_OUT	0x116
++		>;
++	};
++
++	pinctrl_pwm4: pwm4grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXFS__PWM4_OUT	0x116
++		>;
++	};
++
++	pinctrl_ecspi2: ecspi2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK		0x82
++			MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI		0x82
++			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO		0x82
++		>;
++	};
++
++	pinctrl_ecspi2_cs: ecspi2cs {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI2_SS0__GPIO5_IO13		0x40000
++		>;
++	};
++
++	pinctrl_eqos: eqosgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC		0x3
++			MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO		0x3
++			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0	0x91
++			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1	0x91
++			MX8MP_IOMUXC_ENET_RD2__ENET_QOS_RGMII_RD2	0x91
++			MX8MP_IOMUXC_ENET_RD3__ENET_QOS_RGMII_RD3	0x91
++			MX8MP_IOMUXC_ENET_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK	0x91
++			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL	0x91
++			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0	0x1f
++			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1	0x1f
++			MX8MP_IOMUXC_ENET_TD2__ENET_QOS_RGMII_TD2	0x1f
++			MX8MP_IOMUXC_ENET_TD3__ENET_QOS_RGMII_TD3	0x1f
++			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL	0x1f
++			MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x1f
++			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22		0x19
++		>;
++	};
++
++	pinctrl_fec: fecgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXD2__ENET1_MDC		0x3
++			MX8MP_IOMUXC_SAI1_RXD3__ENET1_MDIO		0x3
++			MX8MP_IOMUXC_SAI1_RXD4__ENET1_RGMII_RD0		0x91
++			MX8MP_IOMUXC_SAI1_RXD5__ENET1_RGMII_RD1		0x91
++			MX8MP_IOMUXC_SAI1_RXD6__ENET1_RGMII_RD2		0x91
++			MX8MP_IOMUXC_SAI1_RXD7__ENET1_RGMII_RD3		0x91
++			MX8MP_IOMUXC_SAI1_TXC__ENET1_RGMII_RXC		0x91
++			MX8MP_IOMUXC_SAI1_TXFS__ENET1_RGMII_RX_CTL	0x91
++			MX8MP_IOMUXC_SAI1_TXD0__ENET1_RGMII_TD0		0x1f
++			MX8MP_IOMUXC_SAI1_TXD1__ENET1_RGMII_TD1		0x1f
++			MX8MP_IOMUXC_SAI1_TXD2__ENET1_RGMII_TD2		0x1f
++			MX8MP_IOMUXC_SAI1_TXD3__ENET1_RGMII_TD3		0x1f
++			MX8MP_IOMUXC_SAI1_TXD4__ENET1_RGMII_TX_CTL	0x1f
++			MX8MP_IOMUXC_SAI1_TXD5__ENET1_RGMII_TXC		0x1f
++			MX8MP_IOMUXC_SAI1_RXD0__GPIO4_IO02		0x19
++		>;
++	};
++
++	pinctrl_flexcan1: flexcan1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SPDIF_RX__CAN1_RX          0x154
++			MX8MP_IOMUXC_SPDIF_TX__CAN1_TX          0x154
++		>;
++	};
++
++	pinctrl_flexcan2: flexcan2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_MCLK__CAN2_RX		0x154
++			MX8MP_IOMUXC_SAI5_RXD3__CAN2_TX		0x154
++		>;
++	};
++
++	pinctrl_flexcan1_reg: flexcan1reggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SPDIF_EXT_CLK__GPIO5_IO05	0x154	/* CAN1_STBY */
++		>;
++	};
++
++	pinctrl_flexcan2_reg: flexcan2reggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI2_MCLK__GPIO4_IO27	0x154	/* CAN2_STBY */
++		>;
++	};
++
++	pinctrl_flexspi0: flexspi0grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_NAND_ALE__FLEXSPI_A_SCLK           0x1c2
++			MX8MP_IOMUXC_NAND_CE0_B__FLEXSPI_A_SS0_B        0x82
++			MX8MP_IOMUXC_NAND_DATA00__FLEXSPI_A_DATA00      0x82
++			MX8MP_IOMUXC_NAND_DATA01__FLEXSPI_A_DATA01      0x82
++			MX8MP_IOMUXC_NAND_DATA02__FLEXSPI_A_DATA02      0x82
++			MX8MP_IOMUXC_NAND_DATA03__FLEXSPI_A_DATA03      0x82
++		>;
++	};
++
++	pinctrl_gpio_led: gpioledgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_NAND_READY_B__GPIO3_IO16	0x19
++		>;
++	};
++
++	pinctrl_i2c1: i2c1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C1_SCL__I2C1_SCL		0x400001c3
++			MX8MP_IOMUXC_I2C1_SDA__I2C1_SDA		0x400001c3
++		>;
++	};
++
++	pinctrl_i2c2: i2c2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C2_SCL__I2C2_SCL		0x400001c3
++			MX8MP_IOMUXC_I2C2_SDA__I2C2_SDA		0x400001c3
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c3
++			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c3
++		>;
++	};
++
++	pinctrl_pcie0: pcie0grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C4_SCL__PCIE_CLKREQ_B		0x61 /* open drain, pull up */
++			MX8MP_IOMUXC_SD1_DATA5__GPIO2_IO07		0x41 /* PCIE_RESET */
++		>;
++	};
++
++	pinctrl_pcie0_reg: pcie0reggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD1_DATA4__GPIO2_IO06		0x41
++		>;
++	};
++
++	pinctrl_pmic: pmicirq {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO03__GPIO1_IO03	0x41
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19	0x41
++		>;
++	};
++
++	pinctrl_pdm: pdmgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXC__AUDIOMIX_PDM_CLK		0xd6
++			MX8MP_IOMUXC_SAI5_RXD0__AUDIOMIX_PDM_BIT_STREAM00	0xd6
++			MX8MP_IOMUXC_SAI5_RXD1__AUDIOMIX_PDM_BIT_STREAM01	0xd6
++			MX8MP_IOMUXC_SAI5_RXD2__AUDIOMIX_PDM_BIT_STREAM02	0xd6
++			MX8MP_IOMUXC_SAI5_RXD3__AUDIOMIX_PDM_BIT_STREAM03	0xd6
++		>;
++	};
++
++	pinctrl_sai2: sai2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI2_TXC__AUDIOMIX_SAI2_TX_BCLK	0xd6
++			MX8MP_IOMUXC_SAI2_TXFS__AUDIOMIX_SAI2_TX_SYNC	0xd6
++			MX8MP_IOMUXC_SAI2_TXD0__AUDIOMIX_SAI2_TX_DATA00	0xd6
++			MX8MP_IOMUXC_SAI2_RXD0__AUDIOMIX_SAI2_RX_DATA00	0xd6
++		>;
++	};
++
++	pinctrl_sai3: sai3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI3_TXFS__AUDIOMIX_SAI3_TX_SYNC	0xd6
++			MX8MP_IOMUXC_SAI3_TXC__AUDIOMIX_SAI3_TX_BCLK	0xd6
++			MX8MP_IOMUXC_SAI3_RXD__AUDIOMIX_SAI3_RX_DATA00	0xd6
++			MX8MP_IOMUXC_SAI3_TXD__AUDIOMIX_SAI3_TX_DATA00	0xd6
++			MX8MP_IOMUXC_SAI3_MCLK__AUDIOMIX_SAI3_MCLK	0xd6
++			MX8MP_IOMUXC_SAI3_RXFS__GPIO4_IO28		0xd6
++			MX8MP_IOMUXC_SAI3_RXC__GPIO4_IO29		0xd6
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_UART1_RXD__UART1_DCE_RX	0x140
++			MX8MP_IOMUXC_UART1_TXD__UART1_DCE_TX	0x140
++			MX8MP_IOMUXC_UART3_RXD__UART1_DCE_CTS	0x140
++			MX8MP_IOMUXC_UART3_TXD__UART1_DCE_RTS	0x140
++		>;
++	};
++
++	pinctrl_typec_mux: typec1muxgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_MCLK__GPIO4_IO20	0x16
++		>;
++	};
++
++	pinctrl_uart2: uart2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_UART2_RXD__UART2_DCE_RX	0x49
++			MX8MP_IOMUXC_UART2_TXD__UART2_DCE_TX	0x49
++		>;
++	};
++
++	pinctrl_uart3: uart3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI1_SCLK__UART3_DCE_RX		0x140
++			MX8MP_IOMUXC_ECSPI1_MOSI__UART3_DCE_TX		0x140
++			MX8MP_IOMUXC_ECSPI1_SS0__UART3_DCE_RTS		0x140
++			MX8MP_IOMUXC_ECSPI1_MISO__UART3_DCE_CTS		0x140
++		>;
++	};
++
++	pinctrl_usb1_vbus: usb1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO14__GPIO1_IO14		0x19
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK	0x190
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD	0x1d0
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0	0x1d0
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d0
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d0
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d0
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK	0x194
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD	0x1d4
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0	0x1d4
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d4
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d4
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d4
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT 0xc1
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK	0x196
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD	0x1d6
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0	0x1d6
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d6
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d6
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d6
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT 0xc1
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CD_B__GPIO2_IO12	0x1c4
++		>;
++	};
++
++	pinctrl_usdhc3: usdhc3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x190
++			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d0
++			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d0
++			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d0
++			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d0
++			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d0
++			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d0
++			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d0
++			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d0
++			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d0
++			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x190
++		>;
++	};
++
++	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x194
++			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d4
++			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d4
++			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d4
++			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d4
++			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d4
++			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d4
++			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d4
++			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d4
++			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d4
++			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x194
++		>;
++	};
++
++	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_NAND_WE_B__USDHC3_CLK	0x196
++			MX8MP_IOMUXC_NAND_WP_B__USDHC3_CMD	0x1d6
++			MX8MP_IOMUXC_NAND_DATA04__USDHC3_DATA0	0x1d6
++			MX8MP_IOMUXC_NAND_DATA05__USDHC3_DATA1	0x1d6
++			MX8MP_IOMUXC_NAND_DATA06__USDHC3_DATA2	0x1d6
++			MX8MP_IOMUXC_NAND_DATA07__USDHC3_DATA3	0x1d6
++			MX8MP_IOMUXC_NAND_RE_B__USDHC3_DATA4	0x1d6
++			MX8MP_IOMUXC_NAND_CE2_B__USDHC3_DATA5	0x1d6
++			MX8MP_IOMUXC_NAND_CE3_B__USDHC3_DATA6	0x1d6
++			MX8MP_IOMUXC_NAND_CLE__USDHC3_DATA7	0x1d6
++			MX8MP_IOMUXC_NAND_CE1_B__USDHC3_STROBE	0x196
++		>;
++	};
++
++	pinctrl_wdog: wdoggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO02__WDOG1_WDOG_B	0xc6
++		>;
++	};
++};
+diff --git a/include/configs/imx8mp_olimex_som_evb.h b/include/configs/imx8mp_olimex_som_evb.h
+new file mode 100644
+index 00000000..1c1d37f6
+--- /dev/null
++++ b/include/configs/imx8mp_olimex_som_evb.h
+@@ -0,0 +1,32 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright 2019 NXP
++ */
++
++#ifndef __IMX8MP_EVK_H
++#define __IMX8MP_EVK_H
++
++#include <linux/sizes.h>
++#include <linux/stringify.h>
++#include <asm/arch/imx-regs.h>
++
++#define CFG_SYS_UBOOT_BASE	(QSPI0_AMBA_BASE + CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR * 512)
++
++#if defined(CONFIG_CMD_NET)
++#define CFG_FEC_MXC_PHYADDR          1
++
++#endif
++
++/* Link Definitions */
++
++#define CFG_SYS_INIT_RAM_ADDR	0x40000000
++#define CFG_SYS_INIT_RAM_SIZE	0x80000
++
++/* Totally 6GB DDR */
++#define CFG_SYS_SDRAM_BASE		0x40000000
++#define PHYS_SDRAM			0x40000000
++#define PHYS_SDRAM_SIZE			0xC0000000	/* 3 GB */
++#define PHYS_SDRAM_2			0x100000000
++#define PHYS_SDRAM_2_SIZE		0x40000000	/* 1 GB */
++
++#endif
+-- 
+2.39.5
+

--- a/scripts/build-boot
+++ b/scripts/build-boot
@@ -25,6 +25,9 @@ bcm2836|bcm2837|bcm2711)
 rk*)
     build-boot-rk "${BOARD_ID}" "${CHIP_ID}" "${DEFCONFIG}" "${TUPLE}"
     ;;
+imx*)
+    build-boot-imx "${BOARD_ID}" "${CHIP_ID}" "${DEFCONFIG}" "${TUPLE}"
+    ;;
 meson-*)
     build-boot-meson "${BOARD_ID}" "${CHIP_ID}" "${DEFCONFIG}" "${TUPLE}"
     ;;

--- a/scripts/build-boot-imx
+++ b/scripts/build-boot-imx
@@ -15,6 +15,7 @@ case "${CHIP_ID}" in
     export BL31="$PWD/arm-trusted-firmware/build/imx8mp/debug/bl31.bin"
     export BINMAN_INDIRS="$PWD/firmware-imx"
     export SCP=/dev/null
+    export U_BOOT_PATCHES_DIR="/debimg/patches/u-boot"
     ;;
 *)
     ;;

--- a/scripts/build-boot-imx
+++ b/scripts/build-boot-imx
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Build SD card image
+
+BOARD_ID="${1}" # For example "apalis_imx6"
+CHIP_ID="${2}" # For example "imx6"
+DEFCONFIG="${3}" # For example "apalis_imx6_defconfig"
+TUPLE="${4}" # For example "arm-linux-gnueabihf"
+
+set -ex
+
+case "${CHIP_ID}" in
+*imx8)
+    build-atf imx8mp "${TUPLE}"
+    build-boot-imx-firmware
+    export BL31="$PWD/arm-trusted-firmware/build/imx8mp/debug/bl31.bin"
+    export BINMAN_INDIRS="$PWD/firmware-imx"
+    export SCP=/dev/null
+    ;;
+*)
+    ;;
+esac
+
+build-u_boot "${DEFCONFIG}" "${TUPLE}"
+
+case "${CHIP_ID}" in
+*imx6)
+    # Copy SPL to 1Kbyte and U-Boot to 69Kbytes from start on i.MX6
+    dd if=u-boot/spl/u-boot-spl.bin of=tmp.img bs=1K seek=1 conv=notrunc
+    dd if=u-boot/u-boot-dtb.img of=tmp.img bs=1K seek=69 conv=notrunc
+    ;;
+*imx8)
+    # Copy flash.bin on i.MX8 to 32Kbytes
+    dd if=u-boot/flash.bin of=tmp.img bs=1K seek=32 conv=notrunc
+    ;;
+*)
+    ;;
+esac

--- a/scripts/build-boot-imx-firmware
+++ b/scripts/build-boot-imx-firmware
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Download and build latest version of i.MX DDR firmware
+
+set -ex
+
+TMP=$PWD
+
+FWIMX_VER=8.28-994fa14
+FWIMX_URL_DEFAULT="https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/"
+
+mkdir -p $TMP/firmware-imx
+wget ${FWIMX_URL_DEFAULT}/firmware-imx-${FWIMX_VER}.bin -O $TMP/firmware-imx/firmware-imx-${FWIMX_VER}.bin
+chmod a+x $TMP/firmware-imx/firmware-imx-${FWIMX_VER}.bin
+cd $TMP/firmware-imx && ./firmware-imx-${FWIMX_VER}.bin --auto-accept
+cd $TMP
+
+cp $TMP/firmware-imx/firmware-imx-${FWIMX_VER}/firmware/ddr/synopsys/* $PWD/firmware-imx
+cp $TMP/firmware-imx/firmware-imx-${FWIMX_VER}/firmware/hdmi/cadence/* $PWD/firmware-imx


### PR DESCRIPTION
This PR is on the back of https://github.com/johang/sd-card-images/discussions/250 , adding i.MX8 build support. 

U-boot on i.MX8MP requires the presence of some DDR-training blobs, which are downloaded in scripts/build-boot-imx-firmware. Most of the PR listed as RFC is due to the license there being "auto-accept" for build purposes.

The board that is being added is a not-yet-upstreamed board, for which upstreaming is in progress. We're adding a u-boot patch accordingly.

Proper i.MX6 support will follow later with boards that have been upstreamed.