### PR TITLE
Add support for Exynos 5422-based Odroid boards

### DIFF
--- a/boards.csv
+++ b/boards.csv
@@ -257,3 +257,5 @@ qemu_arm_virt,QEMU arm virt,QEMU,qemu-arm,qemu_arm_defconfig,arm-linux-gnueabihf
 qemu_aarch64_virt,QEMU aarch64 virt,QEMU,qemu-aarch64,qemu_arm64_defconfig,aarch64-linux-gnu,N/A
 qemu_x86_virt,QEMU x86 virt,QEMU,qemu-x86,qemu-x86_defconfig,i686-linux-gnu,N/A
 qemu_x86_64_virt,QEMU x86_64 virt,QEMU,qemu-x86_64,qemu-x86_64_defconfig,x86_64-linux-gnu,N/A
+
+odroid_xu4,Odroid XU3/XU4/HC1/HC2,HardKernel,samsung-xu5422,odroid_xu3_defconfig,arm-linux-gnueabihf,exynos5422-odroidxu4.dts

--- a/chips.csv
+++ b/chips.csv
@@ -48,3 +48,5 @@ qemu-arm,arm,QEMU,ARM Cortex A15,armv7,armhf
 qemu-aarch64,aarch64,QEMU,ARM Cortex A53,armv8,arm64
 qemu-x86_64,x86_64,QEMU,x86 qemu64,x86-64,amd64
 qemu-x86,x86,QEMU,x86 qemu32,x86,i386
+
+samsung-xu5422,Exynos 5422,Samsung,ARM Cortex A15/A7,armv7,armhf

--- a/scripts/build-boot
+++ b/scripts/build-boot
@@ -28,6 +28,9 @@ rk*)
 meson-*)
     build-boot-meson "${BOARD_ID}" "${CHIP_ID}" "${DEFCONFIG}" "${TUPLE}"
     ;;
+samsung-*)
+    build-boot-samsung "${BOARD_ID}" "${CHIP_ID}" "${DEFCONFIG}" "${TUPLE}"
+    ;;
 qemu*)
     build-boot-qemu "${BOARD_ID}" "${CHIP_ID}" "${DEFCONFIG}" "${TUPLE}"
     ;;

--- a/scripts/build-boot-samsung
+++ b/scripts/build-boot-samsung
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Build SD card image
+
+BOARD_ID="${1}" # For example "odroid-xu4"
+CHIP_ID="${2}" # For example "samsung-xu5422"
+DEFCONFIG="${3}" # For example "odroid_xu3_defconfig"
+TUPLE="${4}" # For example "arm-linux-gnueabihf"
+
+set -ex
+
+XU5422_UBOOT_BLX_GIT_URL_DEFAULT="https://github.com/hardkernel/u-boot"
+XU5422_UBOOT_BLX_BRANCH="odroidxu4-v2017.05"
+
+if [ -n "${XU5422_BLX_GIT_REV}" ]
+then
+    git clone --depth 1 \
+              --reference-if-able "bl1_bl2" \
+              --branch ${XU5422_UBOOT_BLX_BRANCH} \
+              "${XU5422_UBOOT_BLX_GIT_URL:-${XU5422_UBOOT_BLX_GIT_URL_DEFAULT}}" bl1_bl2
+else
+    git clone --depth 1 \
+              --reference-if-able "bl1_bl2" \
+              --branch ${XU5422_UBOOT_BLX_BRANCH} \
+              "${XU5422_UBOOT_BLX_GIT_URL:-${XU5422_UBOOT_BLX_GIT_URL_DEFAULT}}" bl1_bl2
+fi
+
+build-u_boot "${DEFCONFIG}" "${TUPLE}"
+
+# SD and eMMC offsets differ
+case "${CHIP_ID}" in
+samsung*)
+	FILE=u-boot.bin
+	BL1_OFFSET=1
+	BL2_OFFSET=31
+	UBOOT_OFFSET=63
+	TZSW_OFFSET=1503
+	;;
+*)
+	echo "Unknown CHIP_ID \"${CHIP_ID}\""
+	exit 1
+esac
+
+# Copy U-Boot to 63 sectors from start
+dd if=u-boot/"${FILE}" of=tmp.img seek=${UBOOT_OFFSET} bs=512 conv=notrunc
+
+# Copy BL1/BL2/TZSW images as required
+dd if=bl1_bl2/sd_fuse/bl1.bin.hardkernel of=tmp.img seek=${BL1_OFFSET} bs=512 conv=notrunc
+dd if=bl1_bl2/sd_fuse/bl2.bin.hardkernel.720k_uboot of=tmp.img seek=${BL2_OFFSET} bs=512 conv=notrunc
+dd if=bl1_bl2/sd_fuse/tzsw.bin.hardkernel of=tmp.img seek=${TZSW_OFFSET} bs=512 conv=notrunc


### PR DESCRIPTION
This PR adds support for the Samsung Exynos 5422-based boards. Board support is for Hardkernel Odroid XU3/XU4/HC1. The bootloader builder downloads BL1/BL2/TZSW blobs from github and adds them to the image. Full boot process is tested with Debian Bookworm.